### PR TITLE
Update to K8S 1.5.2 and trim down master size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ aws-deps:
 cluster: aws-deps
 	$(KOPS_CMD) get cluster | grep -v $(CLUSTER_NAME).$(DOMAIN) || \
 	$(KOPS_CMD) create cluster --name $(CLUSTER_NAME).$(DOMAIN) \
-		--cloud aws --zones $(REGION)a --kubernetes-version 1.5.1 --yes
+		--cloud aws --zones $(REGION)a --kubernetes-version 1.5.2 \
+		--master-size t2.large --yes
 	EDITOR='./ed.sh manifests/kops/regular-ig.yaml' $(KOPS_CMD) edit ig nodes
 	EDITOR='./ed.sh manifests/kops/prometheus-ig.yaml' $(KOPS_CMD) create ig prometheus
 	$(KOPS_CMD) update cluster --yes

--- a/manifests/kops/prometheus-ig.yaml
+++ b/manifests/kops/prometheus-ig.yaml
@@ -2,7 +2,6 @@ metadata:
   name: prometheus
 spec:
   associatePublicIp: true
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
   machineType: c3.2xlarge
   maxSize: 1
   minSize: 1

--- a/manifests/kops/regular-ig.yaml
+++ b/manifests/kops/regular-ig.yaml
@@ -2,7 +2,6 @@ metadata:
   name: nodes
 spec:
   associatePublicIp: true
-  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
   machineType: t2.medium
   maxSize: 2
   minSize: 2


### PR DESCRIPTION
@fabxc @brancz 

After this, it will spin up 1.5.2 clusters.
Also trimmed down the instance size for master since it's not going to be that busy.