### PR TITLE
Add query group name, catch connection errors and enable range queries

### DIFF
--- a/apps/load-generator/Dockerfile
+++ b/apps/load-generator/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3
 
-COPY main.py /usr/src/app/
 COPY requirements.txt /usr/src/app/
-
 RUN pip install -r /usr/src/app/requirements.txt
+
+COPY main.py /usr/src/app/
 
 WORKDIR /usr/src/app
 

--- a/apps/load-generator/main.py
+++ b/apps/load-generator/main.py
@@ -55,17 +55,17 @@ class Querier(object):
     """
     Querier launches groups of queries against a Prometheus service.
     """
-    def __init__(self, i, t, qg, hist):
+    def __init__(self, t, qg, hist):
         self.url = "http://prometheus-test-%s.default:9090/api/v1/query?" % t
         self.interval = qg["intervalSeconds"]
         self.queries = qg["queries"]
-        self.i = i
+        self.groupName = qg["name"]
         self.t = t
 
         self.query_time = hist
 
     def run(self):
-        print("run querier %s %s" % (self.t, self.i))
+        print("run querier %s %s" % (self.t, self.groupName))
 
         while True:
             start = time.time()
@@ -84,7 +84,7 @@ class Querier(object):
         dur = time.time() - start
         print("query %s %s, status=%s, size=%d, dur=%d" %(self.t, q, resp.status_code, len(resp.text), dur))
 
-        self.query_time.labels(self.t, str(self.i), q).observe(dur)
+        self.query_time.labels(self.t, str(self.groupName), q).observe(dur)
 
 
 def main():
@@ -119,7 +119,7 @@ def main():
     for t in config["querier"]["targets"]:
         i = 0
         for g in config["querier"]["queryGroups"]:
-            p = threading.Thread(target=Querier(i, t["name"], g, hist).run)
+            p = threading.Thread(target=Querier(t["name"], g, hist).run)
             p.start()
             i += 1
 

--- a/apps/load-generator/main.py
+++ b/apps/load-generator/main.py
@@ -78,13 +78,16 @@ class Querier(object):
                 time.sleep(wait)
 
     def query(self, q):
-        start = time.time()
-        resp = requests.get(self.url, params={"query": q})
-        
-        dur = time.time() - start
-        print("query %s %s, status=%s, size=%d, dur=%d" %(self.t, q, resp.status_code, len(resp.text), dur))
+        try:
+            start = time.time()
+            resp = requests.get(self.url, params={"query": q})
 
-        self.query_time.labels(self.t, str(self.groupName), q).observe(dur)
+            dur = time.time() - start
+            print("query %s %s, status=%s, size=%d, dur=%d" %(self.t, q, resp.status_code, len(resp.text), dur))
+
+            self.query_time.labels(self.t, self.groupName, q).observe(dur)
+        except requests.exceptions.ConnectionError as e:
+            print("Could not query prometheus instance %s. \n %s" %(self.url, e))
 
 
 def main():

--- a/apps/load-generator/main.py
+++ b/apps/load-generator/main.py
@@ -56,7 +56,7 @@ class Querier(object):
     Querier launches groups of queries against a Prometheus service.
     """
     def __init__(self, t, qg, hist):
-        self.url = "http://prometheus-test-%s.default:9090/api/v1/query?" % t
+        self.url = "http://prometheus-test-%s.default:9090/api/v1/" % t
         self.interval = qg["intervalSeconds"]
         self.queries = qg["queries"]
         self.groupName = qg["name"]
@@ -80,7 +80,13 @@ class Querier(object):
     def query(self, q):
         try:
             start = time.time()
-            resp = requests.get(self.url, params={"query": q})
+
+            params={"query": q["queryString"]}
+            if q["type"] == "query_range":
+                params["start"] = q["start"]
+                params["end"] = q["end"]
+                params["step"] = q["step"]
+            resp = requests.get(self.url + q["type"] + "?", params)
 
             dur = time.time() - start
             print("query %s %s, status=%s, size=%d, dur=%d" %(self.t, q, resp.status_code, len(resp.text), dur))

--- a/apps/load-generator/main.py
+++ b/apps/load-generator/main.py
@@ -7,6 +7,7 @@ import sys
 import requests
 import yaml
 import threading
+from datetime import timedelta
 
 from prometheus_client import start_http_server, Histogram, Counter
 
@@ -55,14 +56,17 @@ class Querier(object):
     """
     Querier launches groups of queries against a Prometheus service.
     """
-    def __init__(self, t, qg, hist):
+    def __init__(self, t, qg, queryTimeHist, totalQueriesCnt, failedQueriesCnt):
         self.url = "http://prometheus-test-%s.default:9090/api/v1/" % t
         self.interval = qg["intervalSeconds"]
         self.queries = qg["queries"]
         self.groupName = qg["name"]
         self.t = t
 
-        self.query_time = hist
+        self.query_time = queryTimeHist
+        self.total_queries = totalQueriesCnt
+        self.failed_queries = failedQueriesCnt
+
 
     def run(self):
         print("run querier %s %s" % (self.t, self.groupName))
@@ -79,22 +83,41 @@ class Querier(object):
 
     def query(self, q):
         try:
+            self.total_queries \
+            .labels(self.t, self.groupName, q["queryString"], q["type"], q.get("start"), q.get("end"), q.get("step")) \
+            .inc()
             start = time.time()
 
             params={"query": q["queryString"]}
             if q["type"] == "query_range":
-                params["start"] = q["start"]
-                params["end"] = q["end"]
+                params["start"] = start - string2Seconds(q["start"])
+                params["end"] = start - string2Seconds(q["end"])
                 params["step"] = q["step"]
+
             resp = requests.get(self.url + q["type"] + "?", params)
 
             dur = time.time() - start
             print("query %s %s, status=%s, size=%d, dur=%d" %(self.t, q, resp.status_code, len(resp.text), dur))
 
-            self.query_time.labels(self.t, self.groupName, q).observe(dur)
-        except requests.exceptions.ConnectionError as e:
+            self.query_time \
+            .labels(self.t, self.groupName, q["queryString"], q["type"], q.get("start"), q.get("end"), q.get("step")) \
+            .observe(dur)
+        except Exception as e:
+            self.failed_queries \
+            .labels(self.t, self.groupName, q["queryString"], q["type"], q.get("start"), q.get("end"), q.get("step")) \
+            .inc()
             print("Could not query prometheus instance %s. \n %s" %(self.url, e))
 
+def string2Seconds(timeString):
+    num = int(timeString[:-1])
+    if timeString.endswith('s'):
+        return timedelta(seconds=num).total_seconds()
+    elif timeString.endswith('m'):
+        return timedelta(minutes=num).total_seconds()
+    elif timeString.endswith('h'):
+        return timedelta(hours=num).total_seconds()
+    elif timeString.endswith('d'):
+        return timedelta(days=num).total_seconds()
 
 def main():
     if len(sys.argv) < 2 or sys.argv[1] not in ["scaler", "querier"]:
@@ -121,14 +144,21 @@ def main():
         Scaler(config["scaler"], url, req_kwargs).run()
         return
 
-    hist = Histogram("loadgen_query_duration_seconds", "Query duration", 
-            ["prometheus", "group", "query"],
-            buckets=(0.01, 0.05, 0.1, 0.3, 0.7, 1.5, 3, 6, 12, 18, 28))
+    queryTimeHist = Histogram("loadgen_query_duration_seconds", "Query duration",
+        ["prometheus", "group", "queryString", "queryType", "start", "end", "step"],
+        buckets=(0.01, 0.05, 0.1, 0.3, 0.7, 1.5, 3, 6, 12, 18, 28))
+    totalQueriesCnt = Counter('loadgen_total_queries', 'Total amount of queries',
+        ["prometheus", "group", "queryString", "queryType", "start", "end", "step"],
+    )
+    failedQueriesCnt = Counter('loadgen_failed_queries', 'Amount of failed queries',
+        ["prometheus", "group", "queryString", "queryType", "start", "end", "step"],
+    )
+
 
     for t in config["querier"]["targets"]:
         i = 0
         for g in config["querier"]["queryGroups"]:
-            p = threading.Thread(target=Querier(t["name"], g, hist).run)
+            p = threading.Thread(target=Querier(t["name"], g, queryTimeHist, totalQueriesCnt, failedQueriesCnt).run)
             p.start()
             i += 1
 

--- a/apps/load-generator/requirements.txt
+++ b/apps/load-generator/requirements.txt
@@ -2,3 +2,4 @@ requests
 pyyaml
 pyopenssl
 prometheus_client
+datetime

--- a/spec.example.yaml
+++ b/spec.example.yaml
@@ -41,24 +41,41 @@ loadGenerator:
     - name: FirstGroup
       intervalSeconds: 4
       queries:
-      - go_goroutines
-      - container_memory_rss
-      - kube_pod_container_info
-      - codelab_api_http_requests_in_progress
-      - codelab_api_requests_total
+      - type: query_range
+        queryString: go_goroutines
+        start: 1489165548
+        end: 1489165569
+        step: 15s
+      - type: query
+        queryString: container_memory_rss
+      - type: query
+        queryString: kube_pod_container_info
+      - type: query
+        queryString: codelab_api_http_requests_in_progress
+      - type: query
+        queryString: codelab_api_requests_total
     - name: SecondGroup
       intervalSeconds: 10
       queries:
-      - sum by(image) (container_memory_rss)
-      - sum by(instance) (rate(node_cpu{mode!="idle"}[2m]))
-      - sum by(instance) (rate(node_cpu[2m]))
-      - sum by(instance) (codelab_api_requests_total)
+      - type: query
+        queryString: sum by(image) (container_memory_rss)
+      - type: query
+        queryString: sum by(instance) (rate(node_cpu{mode!="idle"}[2m]))
+      - type: query
+        queryString: sum by(instance) (rate(node_cpu[2m]))
+      - type: query
+        queryString: sum by(instance) (codelab_api_requests_total)
     - name: thirdGroup
       intervalSeconds: 20
       queries:
-      - rate(codelab_api_requests_total[1m])
-      - sum without(instance) (rate(codelab_api_requests_total[1m]))
-      - histogram_quantile(0.99, sum by(path, le) (rate(codelab_api_request_duration_seconds_bucket[1m])))
-      - histogram_quantile(0.99, sum by(path, method, le) (rate(codelab_api_request_duration_seconds_bucket[1m])))
-      - histogram_quantile(0.99, sum by(instance, le) (rate(codelab_api_request_duration_seconds_bucket[1m])))
+      - type: query
+        queryString: rate(codelab_api_requests_total[1m])
+      - type: query
+        queryString: sum without(instance) (rate(codelab_api_requests_total[1m]))
+      - type: query
+        queryString: histogram_quantile(0.99, sum by(path, le) (rate(codelab_api_request_duration_seconds_bucket[1m])))
+      - type: query
+        queryString: histogram_quantile(0.99, sum by(path, method, le) (rate(codelab_api_request_duration_seconds_bucket[1m])))
+      - type: query
+        queryString: histogram_quantile(0.99, sum by(instance, le) (rate(codelab_api_request_duration_seconds_bucket[1m])))
       

--- a/spec.example.yaml
+++ b/spec.example.yaml
@@ -38,20 +38,23 @@ loadGenerator:
     - name: v1-5-2
     # Groups of queries that are launched independently.
     queryGroups:
-    - intervalSeconds: 4
+    - name: FirstGroup
+      intervalSeconds: 4
       queries:
       - go_goroutines
       - container_memory_rss
       - kube_pod_container_info
       - codelab_api_http_requests_in_progress
       - codelab_api_requests_total
-    - intervalSeconds: 10
+    - name: SecondGroup
+      intervalSeconds: 10
       queries:
       - sum by(image) (container_memory_rss)
       - sum by(instance) (rate(node_cpu{mode!="idle"}[2m]))
       - sum by(instance) (rate(node_cpu[2m]))
       - sum by(instance) (codelab_api_requests_total)
-    - intervalSeconds: 20
+    - name: thirdGroup
+      intervalSeconds: 20
       queries:
       - rate(codelab_api_requests_total[1m])
       - sum without(instance) (rate(codelab_api_requests_total[1m]))

--- a/spec.example.yaml
+++ b/spec.example.yaml
@@ -43,8 +43,8 @@ loadGenerator:
       queries:
       - type: query_range
         queryString: go_goroutines
-        start: 1489165548
-        end: 1489165569
+        start: 2h
+        end: 1h
         step: 15s
       - type: query
         queryString: container_memory_rss


### PR DESCRIPTION
1. Add query group name
2. Try catch requests.exceptions.ConnectionError when querying prometheus intances
3. Enables specification of range queries with start, end and step parameters next to normal queries