### PR TITLE
fake-webserver: Do not collect go_* and process_* metrics

### DIFF
--- a/apps/fake-webserver/main.go
+++ b/apps/fake-webserver/main.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -20,7 +20,10 @@ func main() {
 
 	for i := 0; i < *n; i++ {
 		mux := http.NewServeMux()
-		mux.Handle("/metrics", prometheus.Handler())
+		mux.Handle("/metrics", promhttp.HandlerFor(
+			registry,
+			promhttp.HandlerOpts{},
+		))
 		go http.ListenAndServe(fmt.Sprintf(":%d", 8080+i), mux)
 	}
 

--- a/apps/fake-webserver/main.go
+++ b/apps/fake-webserver/main.go
@@ -4,13 +4,31 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"net/http/pprof"
+	"os"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
-	n = flag.Int("port-count", 5, "Number of sequential ports to serve metrics on, starting at 8080.")
+	n = flag.Int(
+		"port-count", 5,
+		"Number of sequential ports to serve metrics on, starting at 8080.",
+	)
+	registerProcessMetrics = flag.Bool(
+		"enable-process-metrics", true,
+		"Include (potentially expensive) process_* metrics.",
+	)
+	registerGoMetrics = flag.Bool(
+		"enable-go-metrics", true,
+		"Include (potentially expensive) go_* metrics.",
+	)
+	allowCompression = flag.Bool(
+		"allow-metrics-compression", true,
+		"Allow gzip compression of metrics.",
+	)
 
 	start = time.Now()
 )
@@ -18,11 +36,25 @@ var (
 func main() {
 	flag.Parse()
 
+	if *registerProcessMetrics {
+		registry.MustRegister(prometheus.NewProcessCollector(os.Getpid(), ""))
+	}
+	if *registerGoMetrics {
+		registry.MustRegister(prometheus.NewGoCollector())
+	}
+
 	for i := 0; i < *n; i++ {
 		mux := http.NewServeMux()
+		mux.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+		mux.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+		mux.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+		mux.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+		mux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
 		mux.Handle("/metrics", promhttp.HandlerFor(
 			registry,
-			promhttp.HandlerOpts{},
+			promhttp.HandlerOpts{
+				DisableCompression: !*allowCompression,
+			},
 		))
 		go http.ListenAndServe(fmt.Sprintf(":%d", 8080+i), mux)
 	}

--- a/apps/fake-webserver/server.go
+++ b/apps/fake-webserver/server.go
@@ -11,6 +11,8 @@ import (
 )
 
 var (
+	registry = prometheus.NewRegistry()
+
 	namespace = "codelab"
 	subsystem = "api"
 
@@ -52,7 +54,7 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(
+	registry.MustRegister(
 		requestsTotal,
 		requestErrorsTotal,
 		requestHistogram,


### PR DESCRIPTION
Those collections are relatively expensive (the former reads the
memstats, which requires a stop-the-world, the latter has to read and
parse a number of files in /proc). In high-frequency-scrape scenarios,
this might have a significant impact on performance.

@fabxc as discussed.