### PR TITLE
Update README with new location of Kubernetes manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you do set a profile name, then make sure you `export AWS_PROFILE=<profile-na
 ## Building a cluster
 Run `make` to create a cluster. This will create all the necesary resources in AWS using terraform and kops.
 After the make command is finished, you cluster will take a little while to completely build and become available.
-A `kubectl` context will be automatically configured for you with the credentials to access the cluster. 
+A `kubectl` context will be automatically configured for you with the credentials to access the cluster.
 You can use it to check if the cluster is done building. Repeat `kubectl cluster-info` until you no longer get an error. Now your cluster is ready.
 
 The automatic build process also deploys Prometheus to the cluster and preconfigures it for Kubernetes service discovery.
@@ -25,5 +25,5 @@ The K8s cluster is created using Kops. This is a fairly opinionated tool and not
 For tweaking the attributes of the nodes, please have a look at the YAML files in `manifests/kops`. These are Kops manifests describing different instance groups.
 You can use them to tweak instance types, number of nodes of each type, labels applied to each node, etc.
 
-Kubernetes manifests used to deploy the default Prometheus and it's configuration are store unde `manifests/prometheus`.
+Kubernetes manifests used to deploy the default Prometheus and it's configuration are stored under `manifests/k8s`.
 Here you can tweak the Prometheus deployment and the configuration file passed to it.


### PR DESCRIPTION
It seems #2 moved the Kubernetes manifests from under `manifests/prometheus` to `manifests/k8s`. This small PR just updates the README to reflect that change.