### PR TITLE
add proxy to receive webhooks from the AM and post github comments

### DIFF
--- a/components/prow/manifests/alertmanager-github-receiver.yaml
+++ b/components/prow/manifests/alertmanager-github-receiver.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alertmanager-github-receiver
+spec:
+  replicas: 1 
+  selector:
+    matchLabels:
+      app: alertmanager-github-receiver
+  template:
+    metadata:
+      labels:
+        app: alertmanager-github-receiver
+    spec: 
+      containers:
+      - name: alertmanager-github-receiver
+        image: docker.io/krasimir/alertmanager-github-receiver
+        imagePullPolicy: Always
+        args:
+        - --authtokenFile=/etc/github/oauth
+        - --org={{ .GITHUB_ORG }}
+        - --repo={{ .GITHUB_REPO }}
+        volumeMounts:
+          - name: oauth-token
+            mountPath: /etc/github
+            readOnly: true
+        ports:
+          - name: webhook
+            containerPort: 9393
+      volumes:
+      - name: oauth-token
+        secret:
+          secretName: oauth-token
+      nodeSelector:
+        cloud.google.com/gke-nodepool: prow
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: alertmanager-github-receiver
+spec:
+  selector:
+    app: alertmanager-github-receiver
+  ports:
+  - port: 80
+    targetPort: webhook
+  


### PR DESCRIPTION
the image `docker.io/krasimir/alertmanager-github-receiver` used in this deployment includes all needed changes from `https://github.com/m-lab/alertmanager-github-receiver` to cover our use case.

I have submited PR's upstream and if these get merged will decide whether to use the upstream image or where to keep this image.

https://github.com/m-lab/alertmanager-github-receiver/pull/16
https://github.com/m-lab/alertmanager-github-receiver/pull/17 
https://github.com/m-lab/alertmanager-github-receiver/pull/18


to test 
```
kubectl apply  -f components/prow/manifests/alertmanager-github-receiver.yaml
```
```
cat <<EOF | kubectl create -f -
kind: Pod
apiVersion: v1
metadata:
  name: debugger
spec: 
  containers:
  - name: debugger
    image: debian
    command:
    - "ping"
    - "google.com" 
    env:
    - name: TERM
      value: xterm
EOF
```
```
kubectl exec -it debugger bash
msg='{
  "version": "4",
  "groupKey": "fakegroupkey",
  "status": "firing",
  "receiver": "http://localhost:9393/v1/receiver",
  "groupLabels": {"alertname": "FoobarIsBroken"},
  "externalURL": "http://localhost:9093",
  "commonAnnotations": {"issue": "4415"},
  "alerts": [
    {
      "labels": {"thing": "value"},
      "status": "firing",
      "startsAt": "2018-06-12T01:00:00Z",
      "endsAt": "2018-06-14T01:00:00Z"
    }
  ]
}'
curl -XPOST --data-binary "${msg}" http://alertmanager-github-receiver/v1/receiver
```
this will post a new comment on `issue=4415`

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>