### PR TITLE
Modify files for different benchmark comments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN \
         make \
 	&& rm -rf /var/lib/apt/lists/*
 
-COPY prombench /bin/prombench
 RUN mkdir -p /prombench/components/prombench/manifests
 
+COPY prombench /prombench/prombench
 COPY Makefile /prombench/Makefile
 COPY components/prombench/nodepools.yaml /prombench/components/prombench/nodepools.yaml
 COPY components/prombench/manifests/benchmark /prombench/components/prombench/manifests/benchmark

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,6 @@
 PROMBENCH_CMD        = ./prombench
 DOCKER_TAG = docker.io/sipian/prombench:v2.0.0
 
-#Prow config has the following args set in it's configuration during deployment
-#	ZONE
-#	PROJECT_ID
-#	CLUSTER_NAME
-#
-#When the start-benchmark/cancel-benchmark prow-job is created, the benchmark plugin adds the following args
-#	PR_NUMBER
-#	RELEASE - which release version to benchmark PR with (Default: master)
-
 deploy:
 	$(PROMBENCH_CMD) gke nodepool create -a /etc/serviceaccount/service-account.json \
 		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} -v PR_NUMBER:${PR_NUMBER} \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
 PROMBENCH_CMD        = ./prombench
 DOCKER_TAG = docker.io/sipian/prombench:v2.0.0
 
+#Prow config has the following args set in it's configuration during deployment
+#	ZONE
+#	PROJECT_ID
+#	CLUSTER_NAME
+#
+#When the start-benchmark/cancel-benchmark prow-job is created, the benchmark plugin adds the following args
+#	PR_NUMBER
+#	RELEASE - which release version to benchmark PR with (Default: master)
+
 deploy:
 	$(PROMBENCH_CMD) gke nodepool create -a /etc/serviceaccount/service-account.json \
 		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} -v PR_NUMBER:${PR_NUMBER} \
@@ -13,8 +22,7 @@ deploy:
 
 clean:
 	$(PROMBENCH_CMD) gke resource delete -a /etc/serviceaccount/service-account.json \
-		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} \
-		-v PR_NUMBER:${PR_NUMBER} -v RELEASE:${RELEASE} \
+		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} -v PR_NUMBER:${PR_NUMBER} \
 		-f components/prombench/manifests/benchmark/1a_namespace.yaml -f components/prombench/manifests/benchmark/1c_cluster-role-binding.yaml
 
 	$(PROMBENCH_CMD) gke nodepool delete -a /etc/serviceaccount/service-account.json \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROMBENCH_CMD        = /bin/prombench
+PROMBENCH_CMD        = ./prombench
 DOCKER_TAG = docker.io/sipian/prombench:v2.0.0
 
 deploy:
@@ -7,16 +7,14 @@ deploy:
 		-f  components/prombench/nodepools.yaml
 
 	$(PROMBENCH_CMD) gke resource apply -a /etc/serviceaccount/service-account.json \
-		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} -v PR_NUMBER:${PR_NUMBER} \
-		-v PROMETHEUS_1_NAME:${PROMETHEUS_1_NAME} -v PROMETHEUS_1_IMAGE:${PROMETHEUS_1_IMAGE} \
-		-v PROMETHEUS_2_NAME:${PROMETHEUS_2_NAME} -v PROMETHEUS_2_IMAGE:${PROMETHEUS_2_IMAGE} \
+		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} \
+		-v PR_NUMBER:${PR_NUMBER} -v RELEASE:${RELEASE} \
 		-f components/prombench/manifests/benchmark
 
 clean:
 	$(PROMBENCH_CMD) gke resource delete -a /etc/serviceaccount/service-account.json \
-		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} -v PR_NUMBER:${PR_NUMBER} \
-		-v PROMETHEUS_1_NAME:${PROMETHEUS_1_NAME} -v PROMETHEUS_1_IMAGE:${PROMETHEUS_1_IMAGE} \
-		-v PROMETHEUS_2_NAME:${PROMETHEUS_2_NAME} -v PROMETHEUS_2_IMAGE:${PROMETHEUS_2_IMAGE} \
+		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} \
+		-v PR_NUMBER:${PR_NUMBER} -v RELEASE:${RELEASE} \
 		-f components/prombench/manifests/benchmark/1a_namespace.yaml -f components/prombench/manifests/benchmark/1c_cluster-role-binding.yaml
 
 	$(PROMBENCH_CMD) gke nodepool delete -a /etc/serviceaccount/service-account.json \

--- a/components/prombench/manifests/benchmark/2_loadgen.yaml
+++ b/components/prombench/manifests/benchmark/2_loadgen.yaml
@@ -112,8 +112,8 @@ spec:
         args:
         - "querier"
         - "prombench-{{ .PR_NUMBER }}"
-        - "{{ .PROMETHEUS_1_NAME }}"
-        - "{{ .PROMETHEUS_2_NAME }}"
+        - "{{ normalise .RELEASE }}"
+        - "pr-{{ .PR_NUMBER }}"
         volumeMounts:
         - name: config-volume
           mountPath: /etc/loadgen

--- a/components/prombench/manifests/benchmark/3_prometheus-test.yaml
+++ b/components/prombench/manifests/benchmark/3_prometheus-test.yaml
@@ -96,23 +96,23 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: prometheus-test-{{ .PROMETHEUS_1_NAME }}
+  name: prometheus-test-{{ normalise .RELEASE }}
   namespace: prombench-{{ .PR_NUMBER }}
   labels:
     app: prometheus
-    prometheus: test-{{ .PROMETHEUS_1_NAME }}
+    prometheus: test-{{ normalise .RELEASE }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: prometheus
-      prometheus: test-{{ .PROMETHEUS_1_NAME }}
+      prometheus: test-{{ normalise .RELEASE }}
   template:
     metadata:
       namespace: prombench-{{ .PR_NUMBER }}
       labels:
         app: prometheus
-        prometheus: test-{{ .PROMETHEUS_1_NAME }}
+        prometheus: test-{{ normalise .RELEASE }}
     spec:
       serviceAccountName: prometheus
       affinity:
@@ -129,7 +129,7 @@ spec:
         runAsUser: 0
       containers:
       - name: prometheus
-        image: {{ .PROMETHEUS_1_IMAGE }}
+        image: quay.io/prometheus/prometheus:{{ .RELEASE }}
         imagePullPolicy: Always
         args: [
           "--config.file=/etc/prometheus/config/prometheus.yaml",
@@ -159,11 +159,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: prometheus-test-{{ .PROMETHEUS_1_NAME }}
+  name: prometheus-test-{{ normalise .RELEASE }}
   namespace: prombench-{{ .PR_NUMBER }}
   labels:
     app: prometheus
-    prometheus: test-{{ .PROMETHEUS_1_NAME }}
+    prometheus: test-{{ normalise .RELEASE }}
 spec:
   ports:
   #should be 1 port
@@ -171,28 +171,28 @@ spec:
     port: 9090
   selector:
     app: prometheus
-    prometheus: test-{{ .PROMETHEUS_1_NAME }}
+    prometheus: test-{{ normalise .RELEASE }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: prometheus-test-{{ .PROMETHEUS_2_NAME }}
+  name: prometheus-test-pr-{{ .PR_NUMBER }}
   namespace: prombench-{{ .PR_NUMBER }}
   labels:
     app: prometheus
-    prometheus: test-{{ .PROMETHEUS_2_NAME }}
+    prometheus: test-pr-{{ .PR_NUMBER }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: prometheus
-      prometheus: test-{{ .PROMETHEUS_2_NAME }}
+      prometheus: test-pr-{{ .PR_NUMBER }}
   template:
     metadata:
       namespace: prombench-{{ .PR_NUMBER }}
       labels:
         app: prometheus
-        prometheus: test-{{ .PROMETHEUS_2_NAME }}
+        prometheus: test-pr-{{ .PR_NUMBER }}
     spec:
       serviceAccountName: prometheus
       affinity:
@@ -209,14 +209,9 @@ spec:
         runAsUser: 0
       containers:
       - name: prometheus
-        image: {{ .PROMETHEUS_2_IMAGE }}
+        image: docker.io/sipian/prometheus-builder:v1.0.0
         imagePullPolicy: Always
-        args: [
-          "--config.file=/etc/prometheus/config/prometheus.yaml",
-          "--storage.tsdb.path=/data",
-          "--storage.tsdb.min-block-duration=15m",
-          "--storage.tsdb.max-block-duration=4h"
-        ]
+        args: ["{{ .PR_NUMBER }}"]
         volumeMounts:
         - name: config-volume
           mountPath: /etc/prometheus/config
@@ -239,11 +234,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: prometheus-test-{{ .PROMETHEUS_2_NAME }}
+  name: prometheus-test-pr-{{ .PR_NUMBER }}
   namespace: prombench-{{ .PR_NUMBER }}
   labels:
     app: prometheus
-    prometheus: test-{{ .PROMETHEUS_2_NAME }}
+    prometheus: test-pr-{{ .PR_NUMBER }}
 spec:
   ports:
   #should be 1 port
@@ -251,4 +246,4 @@ spec:
     port: 9090
   selector:
     app: prometheus
-    prometheus: test-{{ .PROMETHEUS_2_NAME }}
+    prometheus: test-pr-{{ .PR_NUMBER }}

--- a/components/prombench/manifests/benchmark/4_node-exporter.yaml
+++ b/components/prombench/manifests/benchmark/4_node-exporter.yaml
@@ -5,13 +5,13 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: node-exporter-prometheus-test-{{ .PROMETHEUS_1_NAME }}
+  name: node-exporter-prometheus-test-{{ normalise .RELEASE }}
   namespace: prombench-{{ .PR_NUMBER }}
 spec:
   selector:
     matchLabels:
       app: node-exporter
-      node: test-{{ .PROMETHEUS_1_NAME }}
+      node: test-{{ normalise .RELEASE }}
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -21,7 +21,7 @@ spec:
       namespace: prombench-{{ .PR_NUMBER }}
       labels:
         app: node-exporter
-        node: test-{{ .PROMETHEUS_1_NAME }}
+        node: test-{{ normalise .RELEASE }}
       name: node-exporter
     spec:
       affinity:
@@ -32,7 +32,7 @@ spec:
               - key: prometheus
                 operator: In
                 values:
-                - test-{{ .PROMETHEUS_1_NAME }}
+                - test-{{ normalise .RELEASE }}
             topologyKey: cloud.google.com/gke-nodepool
       securityContext:
         runAsNonRoot: true
@@ -72,13 +72,13 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: node-exporter-prometheus-test-{{ .PROMETHEUS_2_NAME }}
+  name: node-exporter-prometheus-test-pr-{{ .PR_NUMBER }}
   namespace: prombench-{{ .PR_NUMBER }}
 spec:
   selector:
     matchLabels:
       app: node-exporter
-      node: test-{{ .PROMETHEUS_2_NAME }}
+      node: test-pr-{{ .PR_NUMBER }}
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -88,7 +88,7 @@ spec:
       namespace: prombench-{{ .PR_NUMBER }}
       labels:
         app: node-exporter
-        node: test-{{ .PROMETHEUS_2_NAME }}
+        node: test-pr-{{ .PR_NUMBER }}
       name: node-exporter
     spec:
       affinity:
@@ -99,7 +99,7 @@ spec:
               - key: prometheus
                 operator: In
                 values:
-                - test-{{ .PROMETHEUS_2_NAME }}
+                - test-pr-{{ .PR_NUMBER }}
             topologyKey: cloud.google.com/gke-nodepool
       securityContext:
         runAsNonRoot: true

--- a/components/prow/manifests/prow_internals_2.yaml
+++ b/components/prow/manifests/prow_internals_2.yaml
@@ -168,7 +168,6 @@ data:
           entrypoint: "registry.svc.ci.openshift.org/ci/entrypoint:latest"
           sidecar: "registry.svc.ci.openshift.org/ci/sidecar:latest"
         gcs_configuration:
-          bucket: "{{ .GCS_BUCKET }}"
           path_strategy: "explicit"
           default_org: "{{ .GITHUB_ORG }}"
           default_repo: "{{ .GITHUB_REPO }}"
@@ -241,34 +240,6 @@ data:
           - name: serviceaccount
             secret:
               secretName: service-account
-          nodeSelector:
-            cloud.google.com/gke-nodepool: prow
-      - name: build-PR-images
-        context: build-PR-images
-        always_run: false
-        skip_report: false
-        agent: kubernetes
-        decorate: true
-        path_alias: /github.com/prometheus/prometheus
-        spec:
-          containers:
-          - image: docker.io/sipian/golang-builder:prow
-            imagePullPolicy: Always
-            command:
-            - "./prow/benchmark_build.sh"
-            volumeMounts:
-            - name: serviceaccount
-              mountPath: /etc/serviceaccount
-              readOnly: true
-            - name: docker-sock
-              mountPath: /var/run/docker.sock
-          volumes:
-          - name: serviceaccount
-            secret:
-              secretName: service-account          
-          - name: docker-sock 
-            hostPath: 
-                path: /var/run/docker.sock
           nodeSelector:
             cloud.google.com/gke-nodepool: prow
 ---

--- a/components/prow/manifests/prow_internals_2.yaml
+++ b/components/prow/manifests/prow_internals_2.yaml
@@ -271,8 +271,6 @@ spec:
         image: docker.io/sipian/hook:2.0.0
         imagePullPolicy: Always
         env:
-        - name: PROMBENCH_PROJECT_ID
-          value: "{{ .PROJECT_ID }}"
         - name: PROMBENCH_INGRESS_IP
           value: "{{ .INGRESS_IP }}"         
         args:


### PR DESCRIPTION
Benchmark comments are now

- /benchmark (If no release version is given, master is considered by default)
- /benchmark master
- /benchmark 2.3.0
- /benchmark stop

Prow does'nt seem to require GCS_BUCKET now
 