### PR TITLE
change the bench machine types and loader configs

### DIFF
--- a/components/prombench/manifests/benchmark/2_loadgen.yaml
+++ b/components/prombench/manifests/benchmark/2_loadgen.yaml
@@ -7,9 +7,9 @@ data:
   config.yaml: |
     scaler:
       name: fake-webserver
-      high: 5
-      low: 2
-      intervalMinutes: 5
+      high: 700
+      low: 100
+      intervalMinutes: 15
     querier:
       groups:
       - name: simple_range

--- a/components/prombench/nodepools.yaml
+++ b/components/prombench/nodepools.yaml
@@ -7,7 +7,7 @@ cluster:
   - name: prometheus-{{ .PR_NUMBER }}
     initialnodecount: 2
     config:
-      machinetype: n1-standard-1
+      machinetype: n1-highmem-32
       imagetype: COS
       disksizegb: 100
       localssdcount: 1  #SSD is used to give fast-lookup to Prometheus servers being benchmarked
@@ -16,7 +16,7 @@ cluster:
   - name: nodes-{{ .PR_NUMBER }}
     initialnodecount: 1
     config:
-      machinetype: n1-standard-2
+      machinetype: n1-highmem-32
       imagetype: COS
       disksizegb: 100
       localssdcount: 0  #use standard HDD. SSD not needed for fake-webservers.

--- a/components/prow/cluster.yaml
+++ b/components/prow/cluster.yaml
@@ -10,5 +10,6 @@ cluster:
   - name: prow
     initialnodecount: 1
     config:
-      machinetype: n1-standard-2
+      machinetype: n1-standard-4
       imagetype: COS
+      disksizegb: 300


### PR DESCRIPTION
It is time to start testing PR's so setting higher machine types
and higher load settings for the loadgenertor.

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>