### PR TITLE
remove echo test job

### DIFF
--- a/components/prow/manifests/prow_internals_2.yaml
+++ b/components/prow/manifests/prow_internals_2.yaml
@@ -174,18 +174,7 @@ data:
         gcs_credentials_secret: "service-account"
 
     log_level: info
-
-    periodics:
-    - interval: 10m
-      agent: kubernetes
-      name: echo-test
-      spec:
-        containers:
-        - image: alpine:latest
-          command: ["/bin/date"]
-        nodeSelector:
-          cloud.google.com/gke-nodepool: prow
-
+    
     # These configurations are NOT for PR presubmits as used by the trigger plugin. 
     # These are used to create prowjobs for the benchmark plugin. 
     presubmits:


### PR DESCRIPTION
I don't see how is this useful and it just filling up the reports screen so removing for now and for checking real prow components status can revisit again.

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>