### PR TITLE
added PersistentVolumeClaim for prometheus-meta

### DIFF
--- a/components/prombench/manifests/results/prometheus-meta.yaml
+++ b/components/prombench/manifests/results/prometheus-meta.yaml
@@ -1,4 +1,15 @@
 apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometeus-meta
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1000Gi
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-meta
@@ -6,9 +17,7 @@ data:
   prometheus.yaml: |
     global:
       scrape_interval: 5s
-
     scrape_configs:
-
     # prometheus-meta job is added separately because prometheus-meta has a
     # web.external-url of INGRESS_IP/prometheus-meta/
     - job_name: prometheus-meta
@@ -112,8 +121,7 @@ spec:
         args:
         - "--config.file=/etc/prometheus/config/prometheus.yaml"
         - "--storage.tsdb.path=/data"
-        - "--storage.tsdb.min-block-duration=15m"
-        - "--storage.tsdb.max-block-duration=4h"
+        - "--storage.tsdb.retention=90d"
         - "--web.external-url=http://{{ .INGRESS_IP }}/prometheus-meta"
         name: prometheus
         volumeMounts:
@@ -126,7 +134,8 @@ spec:
         configMap:
           name: prometheus-meta
       - name: data
-        emptyDir: {}
+        persistentVolumeClaim:
+          claimName: prometeus-meta
       terminationGracePeriodSeconds: 300
       nodeSelector:
         cloud.google.com/gke-nodepool: prow

--- a/provider/k8s/k8s.go
+++ b/provider/k8s/k8s.go
@@ -97,6 +97,8 @@ func (c *K8s) ResourceApply(deployments []provider.ResourceFile) error {
 				err = c.serviceAccountApply(resource)
 			case "secret":
 				err = c.secretApply(resource)
+			case "persistentvolumeclaim":
+				err = c.persistentVolumeClaimApply(resource)
 			default:
 				err = fmt.Errorf("creating request for unimplimented resource type:%v", kind)
 			}
@@ -156,6 +158,8 @@ func (c *K8s) ResourceDelete(deployments []provider.ResourceFile) error {
 				err = c.serviceAccountDelete(resource)
 			case "secret":
 				err = c.secretDelete(resource)
+			case "persistentvolumeclaim":
+				err = c.persistentVolumeClaimDelete(resource)
 			default:
 				err = fmt.Errorf("deleting request for unimplimented resource type:%v", kind)
 			}
@@ -674,6 +678,47 @@ func (c *K8s) secretApply(resource runtime.Object) error {
 	return nil
 }
 
+func (c *K8s) persistentVolumeClaimApply(resource runtime.Object) error {
+	req := resource.(*apiCoreV1.PersistentVolumeClaim)
+	kind := req.GetObjectKind().GroupVersionKind().Kind
+	if len(req.Namespace) == 0 {
+		req.Namespace = "default"
+	}
+	switch v := resource.GetObjectKind().GroupVersionKind().Version; v {
+	case "v1":
+		client := c.clt.CoreV1().PersistentVolumeClaims(req.Namespace)
+		list, err := client.List(apiMetaV1.ListOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "error listing resource : %v, name: %v", kind, req.Name)
+		}
+
+		var exists bool
+		for _, l := range list.Items {
+			if l.Name == req.Name {
+				exists = true
+				break
+			}
+		}
+
+		if exists {
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, err := client.Update(req)
+				return err
+			}); err != nil {
+				return errors.Wrapf(err, "resource update failed - kind: %v, name: %v", kind, req.Name)
+			}
+			log.Printf("resource updated - kind: %v, name: %v", kind, req.Name)
+			return nil
+		} else if _, err := client.Create(req); err != nil {
+			return errors.Wrapf(err, "resource creation failed - kind: %v, name: %v", kind, req.Name)
+		}
+		log.Printf("resource created - kind: %v, name: %v", kind, req.Name)
+	default:
+		return fmt.Errorf("unknown object version: %v kind:'%v', name:'%v'", v, kind, req.Name)
+	}
+	return nil
+}
+
 // Functions to delete resources
 func (c *K8s) clusterRoleDelete(resource runtime.Object) error {
 	req := resource.(*rbac.ClusterRole)
@@ -907,6 +952,26 @@ func (c *K8s) secretDelete(resource runtime.Object) error {
 	switch v := resource.GetObjectKind().GroupVersionKind().Version; v {
 	case "v1":
 		client := c.clt.CoreV1().Secrets(req.Namespace)
+		delPolicy := apiMetaV1.DeletePropagationForeground
+		if err := client.Delete(req.Name, &apiMetaV1.DeleteOptions{PropagationPolicy: &delPolicy}); err != nil {
+			return errors.Wrapf(err, "resource delete failed - kind: %v, name: %v", kind, req.Name)
+		}
+		log.Printf("resource deleted - kind: %v , name: %v", kind, req.Name)
+	default:
+		return fmt.Errorf("unknown object version: %v kind:'%v', name:'%v'", v, kind, req.Name)
+	}
+	return nil
+}
+
+func (c *K8s) persistentVolumeClaimDelete(resource runtime.Object) error {
+	req := resource.(*apiCoreV1.PersistentVolumeClaim)
+	kind := resource.GetObjectKind().GroupVersionKind().Kind
+	if len(req.Namespace) == 0 {
+		req.Namespace = "default"
+	}
+	switch v := resource.GetObjectKind().GroupVersionKind().Version; v {
+	case "v1":
+		client := c.clt.CoreV1().PersistentVolumeClaims(req.Namespace)
 		delPolicy := apiMetaV1.DeletePropagationForeground
 		if err := client.Delete(req.Name, &apiMetaV1.DeleteOptions{PropagationPolicy: &delPolicy}); err != nil {
 			return errors.Wrapf(err, "resource delete failed - kind: %v, name: %v", kind, req.Name)


### PR DESCRIPTION
it requests and dedicates a hdd
attached to the prometheus-meta pod
for persisisting the data

also added the command to the prombenh tool
to support this deployment type.

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>