### PR TITLE
replace INGESS_IP with a domain name

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,31 +67,39 @@ kubectl create secret generic hmac-token --from-literal=hmac=$HMAC_TOKEN
 kubectl create secret generic service-account --from-file=service-account.json=$AUTH_FILE
 ```
 
-- Deploy all internal prow components and the [nginx-ingress-controller](https://github.com/kubernetes/ingress-nginx) which will be used to access all public components.
+- Deploy the [nginx-ingress-controller](https://github.com/kubernetes/ingress-nginx) which will be used to access all public components.
 ```
 ./prombench gke resource apply -a $AUTH_FILE -v ZONE:$ZONE -v CLUSTER_NAME:$CLUSTER_NAME \
 -v GCLOUD_SERVICEACCOUNT_CLIENTID:$GCLOUD_SERVICEACCOUNT_CLIENTID \
 -f components/prow/manifests/rbac.yaml -f components/prow/manifests/nginx-controller.yaml
+```
 
-export INGRESS_IP=$(kubectl get ingress ing -o go-template='{{ range .status.loadBalancer.ingress}}{{.ip}}{{ end }}')
+Get the ip using
+```
+kubectl get ingress ing -o go-template='{{ range .status.loadBalancer.ingress}}{{.ip}}{{ end }}'
+```
+and use it to set the DNS ip record for `prombench.prometheus.io`
 
+- Deploy all internal prow components
+```
 kubectl apply -f components/prow/manifests/prow_internals_1.yaml
 
 ./prombench gke resource apply -a $AUTH_FILE -v PROJECT_ID:$PROJECT_ID \
--v ZONE:$ZONE -v CLUSTER_NAME:$CLUSTER_NAME -v INGRESS_IP:$INGRESS_IP \
+-v ZONE:$ZONE -v CLUSTER_NAME:$CLUSTER_NAME \
 -v GITHUB_ORG:$GITHUB_ORG -v GITHUB_REPO:$GITHUB_REPO \
 -f components/prow/manifests/prow_internals_2.yaml
 ```
 
 - Deploy grafana & prometheus-meta.
 ```
+export INGRESS_IP=$(kubectl get ingress ing -o go-template='{{ range .status.loadBalancer.ingress}}{{.ip}}{{ end }}')
+
 ./prombench gke resource apply -a $AUTH_FILE -v PROJECT_ID:$PROJECT_ID \
 -v ZONE:$ZONE -v CLUSTER_NAME:$CLUSTER_NAME -v INGRESS_IP:$INGRESS_IP \
 -v GRAFANA_ADMIN_PASSWORD:$GRAFANA_ADMIN_PASSWORD -f components/prombench/manifests/results
 ```
 
 The services will be accessible at the following links:
-  * Grafana ::  http://$INGRESS-IP/grafana
-  * Prometheus ::  http://$INGRESS-IP/prometheus-meta
-  * Prow dashboard :: http://$INGRESS-IP/
-  * Prow hook :: http://$INGRESS-IP/hook
+  * Grafana ::  http://prombench.prometheus.io/grafana
+  * Prometheus ::  http://prombench.prometheus.io/prometheus-meta
+  * Prow dashboard :: http://prombench.prometheus.io/

--- a/components/prow/manifests/prow_internals_2.yaml
+++ b/components/prow/manifests/prow_internals_2.yaml
@@ -157,7 +157,7 @@ metadata:
 data:
   config.yaml: |
     plank:
-      job_url_template: 'http://{{ .INGRESS_IP }}/log?job={{"{{"}}.Spec.Job{{"}}"}}&id={{"{{"}}.Status.BuildID{{"}}"}}'
+      job_url_template: 'http://prombench.prometheus.io/log?job={{"{{"}}.Spec.Job{{"}}"}}&id={{"{{"}}.Status.BuildID{{"}}"}}'
       pod_pending_timeout: 60m
       default_decoration_config:
         timeout: 7200000000000 # 2h
@@ -259,9 +259,6 @@ spec:
       - name: hook
         image: docker.io/sipian/hook:2.0.0
         imagePullPolicy: Always
-        env:
-        - name: PROMBENCH_INGRESS_IP
-          value: "{{ .INGRESS_IP }}"         
         args:
         - --dry-run=false
         ports:


### PR DESCRIPTION
this way we don't need to pass the env variable arround
and less likely to brake.
for local dev env can still use /etc/hosts
to point it to another prow installation.


Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>