### PR TITLE
Handle case of ongoing nodepool operation during creation

### DIFF
--- a/provider/gke/gke.go
+++ b/provider/gke/gke.go
@@ -219,7 +219,7 @@ func (c *GKE) NodePoolCreate(*kingpin.ParseContext) error {
 			err := provider.RetryUntilTrue(
 				fmt.Sprintf("creating operation to create nodepool:%v", reqN.NodePool.Name),
 				func() (bool, error) {
-					return c.nodePoolCreateOperation(reqN)
+					return c.nodePoolCreated(reqN)
 				})
 
 			if err != nil {
@@ -242,7 +242,7 @@ func (c *GKE) NodePoolCreate(*kingpin.ParseContext) error {
 
 // nodePoolCreateOperation checks if there is any ongoing NodePool operation on the cluster
 // when creating a NodePool
-func (c *GKE) nodePoolCreateOperation(req *containerpb.CreateNodePoolRequest) (bool, error) {
+func (c *GKE) nodePoolCreated(req *containerpb.CreateNodePoolRequest) (bool, error) {
 
 	rep, err := c.clientGKE.CreateNodePool(c.ctx, req)
 	if err != nil {

--- a/provider/gke/gke.go
+++ b/provider/gke/gke.go
@@ -240,7 +240,7 @@ func (c *GKE) NodePoolCreate(*kingpin.ParseContext) error {
 	return nil
 }
 
-// nodePoolCreateOperation checks if there is any ongoing NodePool operation on the cluster
+// nodePoolCreated checks if there is any ongoing NodePool operation on the cluster
 // when creating a NodePool
 func (c *GKE) nodePoolCreated(req *containerpb.CreateNodePoolRequest) (bool, error) {
 

--- a/provider/gke/gke.go
+++ b/provider/gke/gke.go
@@ -217,17 +217,17 @@ func (c *GKE) NodePoolCreate(*kingpin.ParseContext) error {
 			log.Printf("Cluster nodepool create request: cluster '%v', nodepool '%v' , project `%s`,zone `%s`", reqN.ClusterId, reqN.NodePool.Name, reqN.ProjectId, reqN.Zone)
 
 			err := provider.RetryUntilTrue(
-				fmt.Sprintf("creating operation to create nodepool:%v", reqN.NodePool.Name),
+				fmt.Sprintf("nodepool creation:%v", reqN.NodePool.Name),
 				func() (bool, error) {
 					return c.nodePoolCreated(reqN)
 				})
 
 			if err != nil {
-				log.Fatalf("Couldn't create operation to create cluster nodepool '%v', file:%v ,err: %v", node.Name, deployment.Name, err)
+				log.Fatalf("Couldn't create cluster nodepool '%v', file:%v ,err: %v", node.Name, deployment.Name, err)
 			}
 
 			err = provider.RetryUntilTrue(
-				fmt.Sprintf("creating nodepool:%v", reqN.NodePool.Name),
+				fmt.Sprintf("checking nodepool running status for:%v", reqN.NodePool.Name)
 				func() (bool, error) {
 					return c.nodePoolRunning(reqN.Zone, reqN.ProjectId, reqN.ClusterId, reqN.NodePool.Name)
 				})

--- a/provider/gke/gke.go
+++ b/provider/gke/gke.go
@@ -223,7 +223,7 @@ func (c *GKE) NodePoolCreate(*kingpin.ParseContext) error {
 				})
 
 			if err != nil {
-				log.Fatalf("nodepool create err:%v", err)
+				log.Fatalf("Couldn't create operation to create cluster nodepool '%v', file:%v ,err: %v", node.Name, deployment.Name, err)
 			}
 
 			err = provider.RetryUntilTrue(
@@ -233,7 +233,7 @@ func (c *GKE) NodePoolCreate(*kingpin.ParseContext) error {
 				})
 
 			if err != nil {
-				log.Fatalf("nodepool create err:%v", err)
+				log.Fatalf("Couldn't create cluster nodepool '%v', file:%v ,err: %v", node.Name, deployment.Name, err)
 			}
 		}
 	}
@@ -257,7 +257,7 @@ func (c *GKE) nodePoolCreateOperation(req *containerpb.CreateNodePoolRequest) (b
 
 			return false, nil
 		}
-		return false, errors.Wrapf(err, "create cluster node pool:%v", req.NodePool.Name)
+		return false, err
 	}
 	log.Printf("cluster node pool status: `%v`", rep.Status)
 	return false, nil
@@ -288,7 +288,7 @@ func (c *GKE) NodePoolDelete(*kingpin.ParseContext) error {
 				func() (bool, error) { return c.nodePoolDeleted(reqD) })
 
 			if err != nil {
-				log.Fatalf("nodepool delete err:%v", err)
+				log.Fatalf("Couldn't delete cluster nodepool '%v', file:%v ,err: %v", node.Name, deployment.Name, err)
 			}
 		}
 	}
@@ -313,7 +313,7 @@ func (c *GKE) nodePoolDeleted(req *containerpb.DeleteNodePoolRequest) (bool, err
 
 			return false, nil
 		}
-		return false, errors.Wrapf(err, "delete cluster node pool:%v", req.NodePoolId)
+		return false, err
 	}
 	log.Printf("cluster node pool status: `%v`", rep.Status)
 	return false, nil


### PR DESCRIPTION
This is to handle errors like

`2018/08/02 03:48:47 Cluster in 'FailedPrecondition' state 'rpc error: code = FailedPrecondition desc = Operation operation-1533161820212-e0451fc6 is currently creating a node pool for cluster prombench. Please wait and try again once it is done.'`