### PR TITLE
Add ready probe for the builder.

### DIFF
--- a/components/prombench/manifests/benchmark/3_prometheus-test.yaml
+++ b/components/prombench/manifests/benchmark/3_prometheus-test.yaml
@@ -92,6 +92,95 @@ data:
         regex: "https-metrics.*"
         target_label: __scheme__
         replacement: https
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-test-pr-{{ .PR_NUMBER }}
+  namespace: prombench-{{ .PR_NUMBER }}
+  labels:
+    app: prometheus
+    prometheus: test-pr-{{ .PR_NUMBER }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+      prometheus: test-pr-{{ .PR_NUMBER }}
+  template:
+    metadata:
+      namespace: prombench-{{ .PR_NUMBER }}
+      labels:
+        app: prometheus
+        prometheus: test-pr-{{ .PR_NUMBER }}
+    spec:
+      serviceAccountName: prometheus
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - prometheus
+      securityContext:
+        runAsUser: 0
+      containers:
+      - name: prometheus
+        image: docker.io/prombench/prometheus-builder:2.0.0
+        imagePullPolicy: Always
+        # The prometheus-builder takes a while to build and run
+        # so make sure we start it before the release deployment.
+        # Mark it ready only when prometheus is started.
+        # This way we have the least time difference in the scraped metrics.
+        readinessProbe:
+          tcpSocket:
+            port: 9090
+          initialDelaySeconds: 30
+          periodSeconds: 1
+        args: ["{{ .PR_NUMBER }}"]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/prometheus/config
+        - name: instance-ssd
+          mountPath: /data
+        ports:
+        - name: prom-web
+          containerPort: 9090
+      volumes:
+      - name: config-volume
+        configMap:
+          name: prometheus-test
+      - name: instance-ssd
+        hostPath:
+          # /mnt is where GKE keeps it's SSD
+          # don't change this if you want Prometheus to take advantage of these local SSDs
+          path: /mnt/disks/ssd0
+      terminationGracePeriodSeconds: 300
+      nodeSelector:
+        cloud.google.com/gke-nodepool: prometheus-{{ .PR_NUMBER }}
+        isolation: prometheus
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-test-pr-{{ .PR_NUMBER }}
+  namespace: prombench-{{ .PR_NUMBER }}
+  labels:
+    app: prometheus
+    prometheus: test-pr-{{ .PR_NUMBER }}
+spec:
+  ports:
+  - name: prom-web
+    port: 80
+    targetPort: prom-web
+  selector:
+    app: prometheus
+    prometheus: test-pr-{{ .PR_NUMBER }}
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -143,7 +232,7 @@ spec:
         - name: instance-ssd
           mountPath: /data
         ports:
-        - name: prom-port
+        - name: prom-web
           containerPort: 9090
       volumes:
       - name: config-volume
@@ -154,9 +243,6 @@ spec:
           # /mnt is where GKE keeps it's SSD
           # don't change this if you want Prometheus to take advantage of these local SSDs
           path: /mnt/disks/ssd0
-      ports:
-      - name: web
-        containerPort: 9090
       terminationGracePeriodSeconds: 300
       nodeSelector:
         cloud.google.com/gke-nodepool: prometheus-{{ .PR_NUMBER }}
@@ -172,94 +258,9 @@ metadata:
     prometheus: test-{{ normalise .RELEASE }}
 spec:
   ports:
-  - name: prometheus
+  - name: prom-web
     port: 80
-    targetPort: prom-port
+    targetPort: prom-web
   selector:
     app: prometheus
     prometheus: test-{{ normalise .RELEASE }}
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: prometheus-test-pr-{{ .PR_NUMBER }}
-  namespace: prombench-{{ .PR_NUMBER }}
-  labels:
-    app: prometheus
-    prometheus: test-pr-{{ .PR_NUMBER }}
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: prometheus
-      prometheus: test-pr-{{ .PR_NUMBER }}
-  template:
-    metadata:
-      namespace: prombench-{{ .PR_NUMBER }}
-      labels:
-        app: prometheus
-        prometheus: test-pr-{{ .PR_NUMBER }}
-    spec:
-      serviceAccountName: prometheus
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - topologyKey: kubernetes.io/hostname
-            labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - prometheus
-      securityContext:
-        runAsUser: 0
-      // The PR builder image takes a little longer to start due to closing and building te binay from scratch.
-      // So to make sure both pods start at the same time we use the init container to check when the other pod is ready.
-      // Without this the scraping graphs will show slightly time shifted to each other.
-      initContainers:
-        - name: init-prometheus-build-ready
-          image: buildpack-deps:18.10-curl
-           command: ['curl', '-m1', '-f','prometheus-pr-{{ .PR_NUMBER }}:9090/-/ready']
-      containers:
-      - name: prometheus
-        image: docker.io/prombench/prometheus-builder:2.0.0
-        imagePullPolicy: Always
-        args: ["{{ .PR_NUMBER }}"]
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/prometheus/config
-        - name: instance-ssd
-          mountPath: /data
-        ports:
-        - name: prom-port
-          containerPort: 9090
-      volumes:
-      - name: config-volume
-        configMap:
-          name: prometheus-test
-      - name: instance-ssd
-        hostPath:
-          # /mnt is where GKE keeps it's SSD
-          # don't change this if you want Prometheus to take advantage of these local SSDs
-          path: /mnt/disks/ssd0
-      terminationGracePeriodSeconds: 300
-      nodeSelector:
-        cloud.google.com/gke-nodepool: prometheus-{{ .PR_NUMBER }}
-        isolation: prometheus
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: prometheus-test-pr-{{ .PR_NUMBER }}
-  namespace: prombench-{{ .PR_NUMBER }}
-  labels:
-    app: prometheus
-    prometheus: test-pr-{{ .PR_NUMBER }}
-spec:
-  ports:
-  - name: prometheus
-    port: 80
-    targetPort: prom-port
-  selector:
-    app: prometheus
-    prometheus: test-pr-{{ .PR_NUMBER }}

--- a/components/prombench/manifests/benchmark/3_prometheus-test.yaml
+++ b/components/prombench/manifests/benchmark/3_prometheus-test.yaml
@@ -154,6 +154,9 @@ spec:
           # /mnt is where GKE keeps it's SSD
           # don't change this if you want Prometheus to take advantage of these local SSDs
           path: /mnt/disks/ssd0
+      ports:
+      - name: web
+        containerPort: 9090
       terminationGracePeriodSeconds: 300
       nodeSelector:
         cloud.google.com/gke-nodepool: prometheus-{{ .PR_NUMBER }}

--- a/components/prombench/manifests/benchmark/3_prometheus-test.yaml
+++ b/components/prombench/manifests/benchmark/3_prometheus-test.yaml
@@ -210,6 +210,13 @@ spec:
                 - prometheus
       securityContext:
         runAsUser: 0
+      // The PR builder image takes a little longer to start due to closing and building te binay from scratch.
+      // So to make sure both pods start at the same time we use the init container to check when the other pod is ready.
+      // Without this the scraping graphs will show slightly time shifted to each other.
+      initContainers:
+        - name: init-prometheus-build-ready
+          image: buildpack-deps:18.10-curl
+           command: ['curl', '-m1', '-f','prometheus-pr-{{ .PR_NUMBER }}:9090/-/ready']
       containers:
       - name: prometheus
         image: docker.io/prombench/prometheus-builder:2.0.0

--- a/components/prombench/manifests/results/prometheus-meta.yaml
+++ b/components/prombench/manifests/results/prometheus-meta.yaml
@@ -139,6 +139,9 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: prometeus-meta
+      ports:
+      - name: web
+        containerPort: 9090
       terminationGracePeriodSeconds: 300
       nodeSelector:
         cloud.google.com/gke-nodepool: prow

--- a/components/prombench/manifests/results/prometheus-meta.yaml
+++ b/components/prombench/manifests/results/prometheus-meta.yaml
@@ -139,9 +139,6 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: prometeus-meta
-      ports:
-      - name: web
-        containerPort: 9090
       terminationGracePeriodSeconds: 300
       nodeSelector:
         cloud.google.com/gke-nodepool: prow


### PR DESCRIPTION
~~this PR includes 2 changes, but since both are in the same file and  want to avoid merge conflicts I can't think of a better way to do this.~~

 - fixes https://github.com/prometheus/prombench/issues/82 - just moved the order of the deployments and added a ready probe - this way we first start the pr builder and when Prometheus is started the probe will mark the deployment as ready and only than it will continue to deploy the release version.This reduced the graph time shift by only 2 secs 
~~- fixes https://github.com/prometheus/prombench/issues/90 - use named ports for Prometheus and just expose it as port 80. This way we even if we decide to change the port that Prometheus listens to wouldn't affect any other config.~~

UPDATE: the second change was done in https://github.com/prometheus/prombench/pull/106 so I removed these changes here.


