### PR TITLE
show the yaml config text when it can't be parsed.

### DIFF
--- a/provider/k8s/k8s.go
+++ b/provider/k8s/k8s.go
@@ -127,7 +127,7 @@ func (c *K8s) ResourceDelete(deployments []provider.ResourceFile) error {
 
 			resource, _, err := decode([]byte(text), nil, nil)
 			if err != nil {
-				return errors.Wrapf(err, "decoding the resource file: %v", deployment.Name)
+				return errors.Wrapf(err, "decoding the resource file:%v, section:%v...", deployment.Name, text[:100])
 			}
 			if resource == nil {
 				continue


### PR DESCRIPTION
yaml error parsing shows the line number of the culprit.
We split the object by "---" and  parse each object separately
so the yaml error line will be relative to the current object.
With this change we also display a small part of the text
so we know where in the main file is the error.

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>