### PR TITLE
moved all dockerfile references to the prombench repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROMBENCH_CMD        = ./prombench
-DOCKER_TAG = docker.io/sipian/prombench:v2.0.0
+DOCKER_TAG = docker.io/prombench/prombench:2.0.0
 
 deploy:
 	$(PROMBENCH_CMD) gke nodepool create -a /etc/serviceaccount/service-account.json \

--- a/components/prombench/manifests/benchmark/2_fake-webserver.yaml
+++ b/components/prombench/manifests/benchmark/2_fake-webserver.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: fake-webserver
-        image: quay.io/fabxc/fake-webserver
+        image: quay.io/prombench/fake-webserver:2.0.0
         ports:
         - name: metrics1
           containerPort: 8080

--- a/components/prombench/manifests/benchmark/2_loadgen.yaml
+++ b/components/prombench/manifests/benchmark/2_loadgen.yaml
@@ -73,7 +73,7 @@ spec:
       serviceAccountName: loadgen-scaler
       containers:
       - name: prom-load-generator
-        image: docker.io/sipian/prombench-loadgen:v2.0.0
+        image: docker.io/prombench/loadgen:2.0.0
         imagePullPolicy: Always
         args:
         - "scaler"
@@ -107,7 +107,7 @@ spec:
     spec:
       containers:
       - name: prom-load-generator
-        image: docker.io/sipian/prombench-loadgen:v2.0.0
+        image: docker.io/prombench/loadgen:2.0.0
         imagePullPolicy: Always
         args:
         - "querier"

--- a/components/prombench/manifests/benchmark/3_prometheus-test.yaml
+++ b/components/prombench/manifests/benchmark/3_prometheus-test.yaml
@@ -209,7 +209,7 @@ spec:
         runAsUser: 0
       containers:
       - name: prometheus
-        image: docker.io/sipian/prometheus-builder:v1.0.0
+        image: docker.io/prombench/prometheus-builder:2.0.0
         imagePullPolicy: Always
         args: ["{{ .PR_NUMBER }}"]
         volumeMounts:

--- a/components/prow/manifests/prow_internals_2.yaml
+++ b/components/prow/manifests/prow_internals_2.yaml
@@ -217,7 +217,7 @@ data:
         agent: kubernetes
         spec:
           containers:
-          - image: docker.io/sipian/prombench:v2.0.0
+          - image: docker.io/prombench/prombench:2.0.0
             imagePullPolicy: Always
             command:
             - "make"
@@ -243,7 +243,7 @@ data:
         agent: kubernetes
         spec:
           containers:
-          - image: docker.io/sipian/prombench:v2.0.0
+          - image: docker.io/prombench/prombench:2.0.0
             imagePullPolicy: Always
             command:
             - "make"
@@ -288,7 +288,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: docker.io/sipian/hook:2.0.0
+        image: docker.io/prombench/hook:2.0.0
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -354,7 +354,7 @@ spec:
       serviceAccountName: "plank"
       containers:
       - name: plank
-        image: docker.io/sipian/plank:2.0.0
+        image: docker.io/prombench/plank:2.0.0
         args:
         - --dry-run=false
         volumeMounts:


### PR DESCRIPTION
fixes https://github.com/prometheus/prombench/issues/97


I also changes some docker tags to be all 2.0.0 so we match with the current prombench version.
This way we can always match the current prombench version with the image tag to be used.

All images have been uploaded to the prombench repo.

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>