### PR TITLE
some small bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ export GCLOUD_SERVICEACCOUNT_CLIENTID=<client_id from the service-account.json>
 ```
 ./prombench gke resource apply -a $AUTH_FILE -v ZONE:$ZONE -v CLUSTER_NAME:$CLUSTER_NAME \
 -f components/prow/manifests/secrets.yaml \
--v HMAC_TOKEN="$(printf $HMAC_TOKEN | base64 -w 0))" \
--v OAUTH_TOKEN="$(printf $OAUTH_TOKEN | base64 -w 0))" \
+-v HMAC_TOKEN="$(printf $HMAC_TOKEN | base64 -w 0)" \
+-v OAUTH_TOKEN="$(printf $OAUTH_TOKEN | base64 -w 0)" \
 -v GKE_AUTH="$(cat $AUTH_FILE | base64 -w 0)"
 
 ```

--- a/components/prombench/apps/load-generator/main.py
+++ b/components/prombench/apps/load-generator/main.py
@@ -137,6 +137,7 @@ def main():
         print("usage: <load_generator> <scaler|querier> <namespace>")
         exit(2)
 
+    global namespace
     namespace = sys.argv[2]
     host = os.environ.get('KUBERNETES_SERVICE_HOST')
     port = os.environ.get('KUBERNETES_PORT_443_TCP_PORT')

--- a/components/prow/manifests/prow_internals_2.yaml
+++ b/components/prow/manifests/prow_internals_2.yaml
@@ -357,6 +357,7 @@ spec:
       containers:
       - name: plank
         image: docker.io/prombench/plank:2.0.0
+        imagePullPolicy: Always
         args:
         - --dry-run=false
         volumeMounts:

--- a/provider/k8s/k8s.go
+++ b/provider/k8s/k8s.go
@@ -66,7 +66,7 @@ func (c *K8s) ResourceApply(deployments []provider.ResourceFile) error {
 
 			resource, _, err := decode([]byte(text), nil, nil)
 			if err != nil {
-				return errors.Wrapf(err, "decoding the resource file:%v", deployment.Name)
+				return errors.Wrapf(err, "decoding the resource file:%v, section:%v...", deployment.Name, text[:100])
 			}
 			if resource == nil {
 				continue


### PR DESCRIPTION
remove extra ")" in the README

incorrect global variable assignment in the scaler/quirier

always pull latest image for plank

when failing to parse a yaml file while applying a resource,
display a small paragraph for easyer debugging.

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>