### PR TITLE
change deployment settings

### DIFF
--- a/components/prombench/manifests/benchmark/2_loadgen.yaml
+++ b/components/prombench/manifests/benchmark/2_loadgen.yaml
@@ -7,8 +7,8 @@ data:
   config.yaml: |
     scaler:
       name: fake-webserver
-      high: 700
-      low: 100
+      high: 80
+      low: 10
       intervalMinutes: 15
     querier:
       groups:

--- a/components/prombench/manifests/benchmark/3_prometheus-test.yaml
+++ b/components/prombench/manifests/benchmark/3_prometheus-test.yaml
@@ -140,7 +140,8 @@ spec:
           tcpSocket:
             port: 9090
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 2
+          failureThreshold: 30
         args: ["{{ .PR_NUMBER }}"]
         volumeMounts:
         - name: config-volume
@@ -223,8 +224,6 @@ spec:
         args: [
           "--config.file=/etc/prometheus/config/prometheus.yaml",
           "--storage.tsdb.path=/data",
-          "--storage.tsdb.min-block-duration=15m",
-          "--storage.tsdb.max-block-duration=4h"
         ]
         volumeMounts:
         - name: config-volume


### PR DESCRIPTION
untill we solve the problem with the scaling(didn't match node selector
error) will use 80 replicas for the fake server.

updated the prom builder probe. Looking at the logs this should work
well.

remove the custom settings for the pr buklder block retention
fixes: https://github.com/prometheus/prombench/issues/95

~~remove the settings to always pull the image for the release deployment
as these don't change so no need to download every time.~~

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>