### PR TITLE
refacotoring of the makefile to make it easyer to use locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,30 @@
 PROMBENCH_CMD        = ./prombench
 DOCKER_TAG = docker.io/prombench/prombench:2.0.0
 
-deploy:
-	$(PROMBENCH_CMD) gke nodepool create -a /etc/serviceaccount/service-account.json \
+ifeq ($(AUTH_FILE),)
+AUTH_FILE = "/etc/serviceaccount/service-account.json"
+endif
+
+deploy: nodepool_create resource_apply
+
+nodepool_create:
+	$(PROMBENCH_CMD) gke nodepool create -a ${AUTH_FILE} \
 		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} -v PR_NUMBER:${PR_NUMBER} \
 		-f  components/prombench/nodepools.yaml
-
-	$(PROMBENCH_CMD) gke resource apply -a /etc/serviceaccount/service-account.json \
+resource_apply:
+	$(PROMBENCH_CMD) gke resource apply -a ${AUTH_FILE} \
 		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} \
 		-v PR_NUMBER:${PR_NUMBER} -v RELEASE:${RELEASE} \
 		-f components/prombench/manifests/benchmark
 
-clean:
-	$(PROMBENCH_CMD) gke resource delete -a /etc/serviceaccount/service-account.json \
+clean: resource_delete nodepool_delete
+
+resource_delete:
+	$(PROMBENCH_CMD) gke resource delete -a ${AUTH_FILE} \
 		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} -v PR_NUMBER:${PR_NUMBER} \
 		-f components/prombench/manifests/benchmark/1a_namespace.yaml -f components/prombench/manifests/benchmark/1c_cluster-role-binding.yaml
-
-	$(PROMBENCH_CMD) gke nodepool delete -a /etc/serviceaccount/service-account.json \
+nodepool_delete:
+	$(PROMBENCH_CMD) gke nodepool delete -a ${AUTH_FILE} \
 		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} -v PR_NUMBER:${PR_NUMBER} \
 		-f components/prombench/nodepools.yaml
 


### PR DESCRIPTION
with this change I can use a custom AUTH_FILE location and use the
makefile locally.
When AUTH_FILE is not set it will use the default value.

Also broken the targets a bit to be able to remove/create nodes and
deployemts separately.

all changes are to make it easyer to use locally

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>