### PR TITLE
overall bench settings update.

### DIFF
--- a/components/prombench/manifests/benchmark/2_loadgen.yaml
+++ b/components/prombench/manifests/benchmark/2_loadgen.yaml
@@ -13,7 +13,7 @@ data:
     querier:
       groups:
       - name: simple_range
-        interval: 4s
+        interval: 2s
         type: range
         start: 2h
         end: 1h
@@ -25,14 +25,14 @@ data:
         - expr: codelab_api_http_requests_in_progress
         - expr: codelab_api_requests_total
       - name: aggr_instant
-        interval: 10s
+        interval: 5s
         type: instant
         queries:
         - expr: sum by(image) (container_memory_rss)
-        - expr: sum by(instance) (rate(node_cpu{mode!="idle"}[2m]))
-        - expr: sum by(instance) (rate(node_cpu[2m]))
-        - expr: sum by(instance) (rate(codelab_api_requests_total[2m]))
-        - expr: sum by(instance) (rate(codelab_api_requests_total{method=~"GET|POST"}[2m]))
+        - expr: sum by(instance) (rate(node_cpu{mode!="idle"}[5m]))
+        - expr: sum by(instance) (rate(node_cpu[5m]))
+        - expr: sum by(instance) (rate(codelab_api_requests_total[5m]))
+        - expr: sum by(instance) (rate(codelab_api_requests_total{method=~"GET|POST"}[5m]))
       - name: aggr_range
         interval: 10s
         type: range
@@ -41,18 +41,18 @@ data:
         step: 15s
         queries:
         - expr: sum by(image) (container_memory_rss)
-        - expr: sum by(instance) (rate(node_cpu{mode!="idle"}[2m]))
-        - expr: sum by(instance) (rate(node_cpu[2m]))
-        - expr: sum by(instance) (rate(codelab_api_requests_total[2m]))
-        - expr: sum by(instance) (rate(codelab_api_requests_total{method=~"GET|POST"}[2m]))
+        - expr: sum by(instance) (rate(node_cpu{mode!="idle"}[5m]))
+        - expr: sum by(instance) (rate(node_cpu[5m]))
+        - expr: sum by(instance) (rate(codelab_api_requests_total[5m]))
+        - expr: sum by(instance) (rate(codelab_api_requests_total{method=~"GET|POST"}[5m]))
       - name: heavy_instant
-        interval: 20s
+        interval: 10s
         queries:
-        - expr: rate(codelab_api_requests_total{method=~"GET|POST"}[1m])
-        - expr: sum without(instance) (rate(codelab_api_requests_total{method=~"GET|POST"}[1m]))
-        - expr: histogram_quantile(0.99, sum by(path, le) (rate(codelab_api_request_duration_seconds_bucket{method="POST"}[1m])))
-        - expr: histogram_quantile(0.99, sum by(path, method, le) (rate(codelab_api_request_duration_seconds_bucket{method="POST"}[1m])))
-        - expr: histogram_quantile(0.99, sum by(instance, le) (rate(codelab_api_request_duration_seconds_bucket{method="POST"}[1m])))
+        - expr: rate(codelab_api_requests_total{method=~"GET|POST"}[5m])
+        - expr: sum without(instance) (rate(codelab_api_requests_total{method=~"GET|POST"}[5m]))
+        - expr: histogram_quantile(0.99, sum by(path, le) (rate(codelab_api_request_duration_seconds_bucket{method="POST"}[5m])))
+        - expr: histogram_quantile(0.99, sum by(path, method, le) (rate(codelab_api_request_duration_seconds_bucket{method="POST"}[5m])))
+        - expr: histogram_quantile(0.99, sum by(instance, le) (rate(codelab_api_request_duration_seconds_bucket{method="POST"}[5m])))
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/components/prombench/manifests/benchmark/3_prometheus-test.yaml
+++ b/components/prombench/manifests/benchmark/3_prometheus-test.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   prometheus.yaml: |
     global:
-      scrape_interval: 1s
+      scrape_interval: 3s
 
     scrape_configs:
     - job_name: kubelets

--- a/components/prombench/nodepools.yaml
+++ b/components/prombench/nodepools.yaml
@@ -7,16 +7,16 @@ cluster:
   - name: prometheus-{{ .PR_NUMBER }}
     initialnodecount: 2
     config:
-      machinetype: n1-highmem-32
+      machinetype: n1-highmem-16
       imagetype: COS
       disksizegb: 100
       localssdcount: 1  #SSD is used to give fast-lookup to Prometheus servers being benchmarked
       labels:
         isolation: prometheus
   - name: nodes-{{ .PR_NUMBER }}
-    initialnodecount: 1
+    initialnodecount: 7
     config:
-      machinetype: n1-highmem-32
+      machinetype: n1-highcpu-16
       imagetype: COS
       disksizegb: 100
       localssdcount: 0  #use standard HDD. SSD not needed for fake-webservers.


### PR DESCRIPTION
this is the current setup that works best so far.

nodecount is increased to 7 as a single k8s node is limited to 100 pods to need 7 when we want to test the system with 700 pods

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>