### PR TITLE
config-update to use many jobs with small number of pods

### DIFF
--- a/components/prombench/manifests/benchmark/2_loadgen.yaml
+++ b/components/prombench/manifests/benchmark/2_loadgen.yaml
@@ -7,8 +7,8 @@ data:
   config.yaml: |
     scaler:
       name: fake-webserver
-      high: 700
-      low: 300
+      high: 20
+      low: 1
       intervalMinutes: 15
     querier:
       groups:

--- a/components/prombench/manifests/benchmark/3_prometheus-test.yaml
+++ b/components/prombench/manifests/benchmark/3_prometheus-test.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   prometheus.yaml: |
     global:
-      scrape_interval: 3s
+      scrape_interval: 5s
 
     scrape_configs:
     - job_name: kubelets
@@ -15,14 +15,12 @@ data:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         insecure_skip_verify: true
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-
       kubernetes_sd_configs:
       - role: node
-
       relabel_configs:
       - action: keep
         source_labels: [__meta_kubernetes_node_label_cloud_google_com_gke_nodepool]
-        regex: prometheus-{{ .PR_NUMBER }}|nodes-{{ .PR_NUMBER }}      
+        regex: prometheus-{{ .PR_NUMBER }}|nodes-{{ .PR_NUMBER }}
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
@@ -32,26 +30,16 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
-    # Scrapes the endpoint lists for the Kubernetes API server
-    # and node-exporter, which we all consider part of a default setup.
-    - job_name: standard-endpoints
-      tls_config:
-        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        # As for kubelets, certificate validation fails for the API server (node)
-        # and we circumvent it for now.
-        insecure_skip_verify: true
-      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-
+    - job_name: node-exporters
       kubernetes_sd_configs:
       - role: endpoints
         namespaces:
           names:
             - prombench-{{ .PR_NUMBER }}
-
       relabel_configs:
       - action: keep
-        source_labels: [__meta_kubernetes_service_label_monitored]
-        regex: true
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: node-exporter
       - action: replace
         source_labels: [__meta_kubernetes_service_name]
         target_label: job
@@ -59,39 +47,656 @@ data:
         source_labels: [__meta_kubernetes_pod_node_name]
         target_label: nodeName
 
-    # Scrapes the endpoint lists for the kube-dns server. Which we consider
-    # part of a default setup.
-    - job_name: kube-components
-      tls_config:
-        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        insecure_skip_verify: true
-      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+    - job_name: fake-webservers-1
       kubernetes_sd_configs:
       - role: endpoints
         namespaces:
           names:
             - prombench-{{ .PR_NUMBER }}
-
       relabel_configs:
-      - action: replace
-        source_labels: [__meta_kubernetes_service_label_k8s_app]
-        target_label: job
       - action: keep
-        source_labels: [__meta_kubernetes_service_name]
-        regex: ".*-prometheus-discovery"
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-2
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
       - action: keep
-        source_labels: [__meta_kubernetes_endpoint_port_name]
-        regex: "http-metrics.*|https-metrics.*"
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
       - action: replace
-        source_labels: [__meta_kubernetes_endpoint_port_name]
-        regex: "https-metrics.*"
-        target_label: __scheme__
-        replacement: https
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-3
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
       - action: replace
-        source_labels: [__meta_kubernetes_endpoint_port_name]
-        regex: "https-metrics.*"
-        target_label: __scheme__
-        replacement: https
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-4
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-5
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-6
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-7
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-8
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-9
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-10
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-11
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-12
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-13
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-14
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-15
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-16
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-17
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-18
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-19
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-20
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-21
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-22
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-23
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-24
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-25
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-26
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-27
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-28
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-29
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-30
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-31
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-32
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-33
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-34
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-35
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-36
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-37
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-38
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-39
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-40
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-41
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-42
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-43
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-44
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-45
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-46
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-47
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-48
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-49
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
+    - job_name: fake-webservers-50
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - prombench-{{ .PR_NUMBER }}
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_service_label_app]
+        regex: fake-webserver
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: nodeName
 
 ---
 apiVersion: apps/v1

--- a/components/prombench/nodepools.yaml
+++ b/components/prombench/nodepools.yaml
@@ -14,9 +14,9 @@ cluster:
       labels:
         isolation: prometheus
   - name: nodes-{{ .PR_NUMBER }}
-    initialnodecount: 7
+    initialnodecount: 1
     config:
-      machinetype: n1-highcpu-16
+      machinetype: n1-highcpu-32
       imagetype: COS
       disksizegb: 100
       localssdcount: 0  #use standard HDD. SSD not needed for fake-webservers.


### PR DESCRIPTION
closes: #132

last SD bug was trigered with a small number of pods and a large number
of jobs.

this also allows us to use a single node for the fake-webserver.

This config is tested to utulize the fake-webserver node at 80% at 20
pods and the Prometheus nodes at around 60% avarage(we need some room
for the compaction processes).

Updated the scrape_interval: to 5s as this is closer to a real
production environment.

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>