### PR TITLE
Setting Lshortfile flag to logger

### DIFF
--- a/cmd/prombench/prombench.go
+++ b/cmd/prombench/prombench.go
@@ -3,6 +3,7 @@ package main // import "github.com/prometheus/prombench/cmd/prombench"
 import (
 	"fmt"
 	"os"
+	"log"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -11,6 +12,7 @@ import (
 )
 
 func main() {
+	log.SetFlags(log.LstdFlags | log.Llongfile)
 
 	app := kingpin.New(filepath.Base(os.Args[0]), "The Prometheus benchmarking tool")
 	app.HelpFlag.Short('h')


### PR DESCRIPTION
Setting Lshortfile flag allows final file name and line number to be displayed when using the go's standard log. A sample output:
```
2018/09/18 17:00:25 main.go:9: Testing
```
Addresses: https://github.com/prometheus/prombench/issues/35