### PR TITLE
Enabled PRW 2.0 on both benchmarked Prometheus servers.

### DIFF
--- a/prombench/manifests/prombench/benchmark/3_prometheus-test-pr_deployment.yaml
+++ b/prombench/manifests/prombench/benchmark/3_prometheus-test-pr_deployment.yaml
@@ -722,6 +722,10 @@ data:
     - url: "http://prometheus-sink:9011/sink/prw" # PRW 1.0
       headers:
         "X-SINK-SOURCE": prometheus-test-pr-{{ .PR_NUMBER }}
+    - url: "http://prometheus-sink:9011/sink/prw" # PRW 2.0
+      protobuf_message: io.prometheus.write.v2.Request
+      headers:
+        "X-SINK-SOURCE": prometheus-test-pr-{{ .PR_NUMBER }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/prombench/manifests/prombench/benchmark/3_prometheus-test-release_deployment.yaml
+++ b/prombench/manifests/prombench/benchmark/3_prometheus-test-release_deployment.yaml
@@ -722,6 +722,10 @@ data:
     - url: "http://prometheus-sink:9011/sink/prw" # PRW 1.0
       headers:
         "X-SINK-SOURCE": prometheus-test-{{ normalise .RELEASE }}
+    - url: "http://prometheus-sink:9011/sink/prw" # PRW 2.0
+      protobuf_message: io.prometheus.write.v2.Request
+      headers:
+        "X-SINK-SOURCE": prometheus-test-{{ normalise .RELEASE }}
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Previous [attempt failed](https://github.com/prometheus/test-infra/pull/821#issuecomment-2627315784) because PRW 2.0 was tied to metadata-wal-records feature. We untied it, so this should work now.