### PR TITLE
Switch Parca storage backend to GCS

### DIFF
--- a/prombench/manifests/cluster-infra/8b_parca.yaml
+++ b/prombench/manifests/cluster-infra/8b_parca.yaml
@@ -1,15 +1,31 @@
+# Parca deployment with GCS storage backend
+# 
+# IMPORTANT: This deployment requires a Kubernetes secret named 'parca-gcs-service-account'
+# containing a GCS service account key JSON file. The secret must have the following structure:
+#
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: parca-gcs-service-account
+# type: Opaque
+# data:
+#   key.json: <base64-encoded-gcs-service-account-key>
+#
+# The GCS service account needs permissions to read/write to the bucket specified in the config.
+#
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: parca
 data:
-  # TODO(bwplotka): Add config reloader, otherwise pod has to manually deleted.
+  # TODO(bwplotka): Add config reloader, otherwise pod has to be manually deleted.
   parca.yaml: |-
     "object_storage":
       "bucket":
         "config":
-          "directory": "/var/lib/parca"
-        "type": "FILESYSTEM"
+          "bucket": "prometheus-parca-profiles"
+          "service_account": ""
+        "type": "GCS"
     scrape_configs:
       - job_name: prometheus
         scrape_interval: 30s
@@ -86,11 +102,15 @@ spec:
         - "--debuginfod-http-request-timeout=5m"
         name: parca
         terminationMessagePolicy: FallbackToLogsOnError
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/secrets/gcs-service-account/key.json
         volumeMounts:
         - mountPath: /etc/parca
           name: config
-        - mountPath: /var/lib/parca
-          name: storage
+        - mountPath: /var/secrets/gcs-service-account
+          name: gcs-service-account
+          readOnly: true
         ports:
         - name: parca-web
           containerPort: 7070
@@ -98,9 +118,9 @@ spec:
       - name: config
         configMap:
           name: parca
-      # TODO(bwplotka): Make it persistent at some point.
-      - name: storage
-        emptyDir: {}
+      - name: gcs-service-account
+        secret:
+          secretName: parca-gcs-service-account
       terminationGracePeriodSeconds: 120
       nodeSelector:
         node-name: main-node


### PR DESCRIPTION
## Summary
- Migrates Parca's storage backend from temporary filesystem to Google Cloud Storage
- Enables persistent storage of profiling data across pod restarts
- Addresses the TODO comment about making storage persistent
- Partially fixes #630

## Changes
- Updated Parca ConfigMap to use GCS bucket configuration instead of filesystem
- Added volume mount for GCS service account credentials
- Removed temporary emptyDir storage volume
- Added documentation explaining the required external secret setup

## Configuration Requirements
This deployment requires a Kubernetes secret named `parca-gcs-service-account` containing a GCS service account key JSON file. The secret should be created separately with appropriate permissions to read/write to the configured GCS bucket (`prometheus-parca-profiles`).