### PR TITLE
Update Prombench dashboard URL to use prNumber variable.

### DIFF
--- a/prombench/manifests/cluster-infra/7a_commentmonitor_configmap_noparse.yaml
+++ b/prombench/manifests/cluster-infra/7a_commentmonitor_configmap_noparse.yaml
@@ -54,7 +54,7 @@ data:
           After successful deployment ([check status here](https://github.com/prometheus/prometheus/actions/workflows/prombench.yml)), the benchmarking results can be viewed at:
 
           - [Prometheus Meta](http://{{ index . "DOMAIN_NAME" }}/prometheus-meta/graph?g0.expr={namespace%3D"prombench-{{ index . "PR_NUMBER" }}"}&g0.tab=1)
-          - [Prombench Dashboard](http://{{ index . "DOMAIN_NAME" }}/grafana/d/7gmLoNDmz/prombench?orgId=1&var-pr-number={{ index . "PR_NUMBER" }})
+          - [Prombench Dashboard](http://{{ index . "DOMAIN_NAME" }}/grafana/d/7gmLoNDmz/prombench?orgId=1&var-prNumber={{ index . "PR_NUMBER" }})
           - [Grafana Exlorer, Loki logs](http://{{ index . "DOMAIN_NAME" }}/grafana/explore?orgId=1&left=["now-6h","now","loki-meta",{},{"mode":"Logs"},{"ui":[true,true,true,"none"]}])
           - [Parca profiles (e.g. in-use memory)](http://{{ index . "DOMAIN_NAME" }}/profiles?expression_a=memory%3Ainuse_space%3Abytes%3Aspace%3Abytes%7Bpr_number%3D%22{{ index . "PR_NUMBER" }}%22%7D&time_selection_a=relative:minute|15)
 
@@ -88,7 +88,7 @@ data:
           After the successful deployment ([check status here](https://github.com/prometheus/prometheus/actions/workflows/prombench.yml)), the benchmarking results can be viewed at:
 
           - [Prometheus Meta](http://{{ index . "DOMAIN_NAME" }}/prometheus-meta/graph?g0.expr={namespace%3D"prombench-{{ index . "PR_NUMBER" }}"}&g0.tab=1)
-          - [Prombench Dashboard](http://{{ index . "DOMAIN_NAME" }}/grafana/d/7gmLoNDmz/prombench?orgId=1&var-pr-number={{ index . "PR_NUMBER" }})
+          - [Prombench Dashboard](http://{{ index . "DOMAIN_NAME" }}/grafana/d/7gmLoNDmz/prombench?orgId=1&var-prNumber={{ index . "PR_NUMBER" }})
           - [Grafana Explorer, Loki logs](http://{{ index . "DOMAIN_NAME" }}/grafana/explore?orgId=1&left=["now-6h","now","loki-meta",{},{"mode":"Logs"},{"ui":[true,true,true,"none"]}])
           - [Parca profiles (e.g. in-use memory)](http://{{ index . "DOMAIN_NAME" }}/profiles?expression_a=memory%3Ainuse_space%3Abytes%3Aspace%3Abytes%7Bpr_number%3D%22{{ index . "PR_NUMBER" }}%22%7D&time_selection_a=relative:minute|15)
 

--- a/tools/comment-monitor/internal/testdata/expectedcomment.restart-no-flags.md
+++ b/tools/comment-monitor/internal/testdata/expectedcomment.restart-no-flags.md
@@ -5,7 +5,7 @@
 After successful deployment ([check status here](https://github.com/prometheus/prometheus/actions/workflows/prombench.yml)), the benchmarking results can be viewed at:
 
 - [Prometheus Meta](http://prombench.example.com/prometheus-meta/graph?g0.expr={namespace%3D"prombench-15487"}&g0.tab=1)
-- [Prombench Dashboard](http://prombench.example.com/grafana/d/7gmLoNDmz/prombench?orgId=1&var-pr-number=15487)
+- [Prombench Dashboard](http://prombench.example.com/grafana/d/7gmLoNDmz/prombench?orgId=1&var-prNumber=15487)
 - [Grafana Exlorer, Loki logs](http://prombench.example.com/grafana/explore?orgId=1&left=["now-6h","now","loki-meta",{},{"mode":"Logs"},{"ui":[true,true,true,"none"]}])
 - [Parca profiles (e.g. in-use memory)](http://prombench.example.com/profiles?expression_a=memory%3Ainuse_space%3Abytes%3Aspace%3Abytes%7Bpr_number%3D%2215487%22%7D&time_selection_a=relative:minute|15)
 

--- a/tools/comment-monitor/internal/testdata/expectedcomment.restart-version.md
+++ b/tools/comment-monitor/internal/testdata/expectedcomment.restart-version.md
@@ -7,7 +7,7 @@
 After successful deployment ([check status here](https://github.com/prometheus/prometheus/actions/workflows/prombench.yml)), the benchmarking results can be viewed at:
 
 - [Prometheus Meta](http://prombench.example.com/prometheus-meta/graph?g0.expr={namespace%3D"prombench-15487"}&g0.tab=1)
-- [Prombench Dashboard](http://prombench.example.com/grafana/d/7gmLoNDmz/prombench?orgId=1&var-pr-number=15487)
+- [Prombench Dashboard](http://prombench.example.com/grafana/d/7gmLoNDmz/prombench?orgId=1&var-prNumber=15487)
 - [Grafana Exlorer, Loki logs](http://prombench.example.com/grafana/explore?orgId=1&left=["now-6h","now","loki-meta",{},{"mode":"Logs"},{"ui":[true,true,true,"none"]}])
 - [Parca profiles (e.g. in-use memory)](http://prombench.example.com/profiles?expression_a=memory%3Ainuse_space%3Abytes%3Aspace%3Abytes%7Bpr_number%3D%2215487%22%7D&time_selection_a=relative:minute|15)
 

--- a/tools/comment-monitor/internal/testdata/expectedcomment.start-no-flags.md
+++ b/tools/comment-monitor/internal/testdata/expectedcomment.start-no-flags.md
@@ -5,7 +5,7 @@
 After the successful deployment ([check status here](https://github.com/prometheus/prometheus/actions/workflows/prombench.yml)), the benchmarking results can be viewed at:
 
 - [Prometheus Meta](http://prombench.example.com/prometheus-meta/graph?g0.expr={namespace%3D"prombench-15487"}&g0.tab=1)
-- [Prombench Dashboard](http://prombench.example.com/grafana/d/7gmLoNDmz/prombench?orgId=1&var-pr-number=15487)
+- [Prombench Dashboard](http://prombench.example.com/grafana/d/7gmLoNDmz/prombench?orgId=1&var-prNumber=15487)
 - [Grafana Explorer, Loki logs](http://prombench.example.com/grafana/explore?orgId=1&left=["now-6h","now","loki-meta",{},{"mode":"Logs"},{"ui":[true,true,true,"none"]}])
 - [Parca profiles (e.g. in-use memory)](http://prombench.example.com/profiles?expression_a=memory%3Ainuse_space%3Abytes%3Aspace%3Abytes%7Bpr_number%3D%2215487%22%7D&time_selection_a=relative:minute|15)
 

--- a/tools/comment-monitor/internal/testdata/expectedcomment.start-version-dir.md
+++ b/tools/comment-monitor/internal/testdata/expectedcomment.start-version-dir.md
@@ -7,7 +7,7 @@
 After the successful deployment ([check status here](https://github.com/prometheus/prometheus/actions/workflows/prombench.yml)), the benchmarking results can be viewed at:
 
 - [Prometheus Meta](http://prombench.example.com/prometheus-meta/graph?g0.expr={namespace%3D"prombench-15487"}&g0.tab=1)
-- [Prombench Dashboard](http://prombench.example.com/grafana/d/7gmLoNDmz/prombench?orgId=1&var-pr-number=15487)
+- [Prombench Dashboard](http://prombench.example.com/grafana/d/7gmLoNDmz/prombench?orgId=1&var-prNumber=15487)
 - [Grafana Explorer, Loki logs](http://prombench.example.com/grafana/explore?orgId=1&left=["now-6h","now","loki-meta",{},{"mode":"Logs"},{"ui":[true,true,true,"none"]}])
 - [Parca profiles (e.g. in-use memory)](http://prombench.example.com/profiles?expression_a=memory%3Ainuse_space%3Abytes%3Aspace%3Abytes%7Bpr_number%3D%2215487%22%7D&time_selection_a=relative:minute|15)
 

--- a/tools/comment-monitor/internal/testdata/expectedcomment.start-version.md
+++ b/tools/comment-monitor/internal/testdata/expectedcomment.start-version.md
@@ -7,7 +7,7 @@
 After the successful deployment ([check status here](https://github.com/prometheus/prometheus/actions/workflows/prombench.yml)), the benchmarking results can be viewed at:
 
 - [Prometheus Meta](http://prombench.example.com/prometheus-meta/graph?g0.expr={namespace%3D"prombench-15487"}&g0.tab=1)
-- [Prombench Dashboard](http://prombench.example.com/grafana/d/7gmLoNDmz/prombench?orgId=1&var-pr-number=15487)
+- [Prombench Dashboard](http://prombench.example.com/grafana/d/7gmLoNDmz/prombench?orgId=1&var-prNumber=15487)
 - [Grafana Explorer, Loki logs](http://prombench.example.com/grafana/explore?orgId=1&left=["now-6h","now","loki-meta",{},{"mode":"Logs"},{"ui":[true,true,true,"none"]}])
 - [Parca profiles (e.g. in-use memory)](http://prombench.example.com/profiles?expression_a=memory%3Ainuse_space%3Abytes%3Aspace%3Abytes%7Bpr_number%3D%2215487%22%7D&time_selection_a=relative:minute|15)
 


### PR DESCRIPTION
This updates the PR comment templates to use var-prNumber instead of var-pr-number in the Prombench dashboard links. This aligns with the dashboard variable change made in PR #660, where the variable was renamed from "pr-number" to "prNumber" because dashes are not allowed in Grafana variable names.

Related: #660