### PR TITLE
feat: Improved prombench dashboard

### DIFF
--- a/prombench/manifests/cluster-infra/dashboards/prombench.json
+++ b/prombench/manifests/cluster-infra/dashboards/prombench.json
@@ -1,4092 +1,6050 @@
 {
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "5.0.0"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "5.0.0"
-    }
-  ],
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": "-- Grafana --",
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "type": "dashboard"
-      }
-    ]
-  },
-  "description": "Metrics useful for benchmarking and loadtesting Prometheus itself. Designed primarily for Prometheus 2.3.x.",
-  "tags": [
-    "benchmark",
-    "node-metrics"
-  ],
-  "editable": true,
-  "gnetId": 6725,
-  "graphTooltip": 1,
-  "id": null,
-  "iteration": 1532083926170,
-  "links": [],
-  "panels": [
-  {
-      "collapsed": true,
-      "gridPos": {
-      "h": 1,
-      "w": 24,
-      "x": 0,
-      "y": 0
-      },
-      "id": 47,
-      "panels": [
-      {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "fill": 1,
-          "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 0,
-          "y": 1
-          },
-          "id": 51,
-          "legend": {
-          "alignAsTable": true,
-          "avg": true,
-          "current": true,
-          "max": true,
-          "min": true,
-          "show": true,
-          "total": false,
-          "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "node_memory_MemTotal_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 1,
-              "legendFormat": "{{node}} - Total memory",
-              "refId": "E"
-          },
-          {
-              "expr": "node_memory_MemTotal_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"} - node_memory_MemFree_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"} - node_memory_Buffers_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"} - node_memory_Cached_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{node}} - Used",
-              "refId": "A"
-          },
-          {
-              "expr": "node_memory_Buffers_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{node}} - Buffers",
-              "refId": "B"
-          },
-          {
-              "expr": "node_memory_Cached_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{node}} - Cached",
-              "refId": "C"
-          },
-          {
-              "expr": "node_memory_MemFree_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{node}} - Free",
-              "refId": "D"
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Memory",
-          "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "bytes",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "fill": 1,
-          "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 12,
-          "y": 1
-          },
-          "id": 53,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "irate(node_disk_io_time_seconds_total{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\",device!~'^(md\\\\\\\\d+$|dm-)'}[5m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{node}} - {{device}}",
-              "refId": "A"
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Disk I/O Utilisation",
-          "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "percentunit",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "fill": 1,
-          "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 0,
-          "y": 10
-          },
-          "id": 57,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "irate(node_context_switches_total{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}[5m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{node}} - Context Switches",
-              "refId": "A"
-          },
-          {
-              "expr": "irate(node_intr_total{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}[5m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{node}} - Interrupts",
-              "refId": "B"
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Context Switches / Interrupts",
-          "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "Disk space used of all filesystems mounted",
-          "fill": 1,
-          "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 12,
-          "y": 10
-          },
-          "id": 61,
-          "legend": {
-          "alignAsTable": true,
-          "avg": true,
-          "current": true,
-          "max": true,
-          "min": true,
-          "show": true,
-          "total": false,
-          "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "100 - ((node_filesystem_avail_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\",device!~'rootfs'} * 100) / node_filesystem_size_bytes{node=~'(test+).*',device!~'rootfs'})",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{node}} - {{mountpoint}}",
-              "refId": "A"
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Disk Space Used Basic",
-          "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "transparent": false,
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "percent",
-              "label": null,
-              "logBase": 1,
-              "max": "100",
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "fill": 1,
-          "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 0,
-          "y": 19
-          },
-          "id": 59,
-          "legend": {
-          "alignAsTable": true,
-          "avg": true,
-          "current": true,
-          "max": true,
-          "min": true,
-          "show": true,
-          "total": false,
-          "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "node_load1{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{node}} - Load 1m",
-              "refId": "A"
-          },
-          {
-              "expr": "node_load5{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{node}} - Load 5m",
-              "refId": "B"
-          },
-          {
-              "expr": "node_load15{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{node}} - Load 15m",
-              "refId": "C"
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "System Load",
-          "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "fill": 1,
-          "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 12,
-          "y": 19
-          },
-          "id": 55,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "1 - node_filesystem_free_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\",fstype!='rootfs',mountpoint!~'/(run|var).*',mountpoint!=''} / node_filesystem_size_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{node}} - {{mountpoint}}",
-              "refId": "A"
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Filesystem Fullness",
-          "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "percentunit",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      }
-      ],
-      "title": "Node Metrics",
-      "type": "row"
-  },
-  {
-      "collapsed": false,
-      "gridPos": {
-      "h": 1,
-      "w": 24,
-      "x": 0,
-      "y": 1
-      },
-      "id": 45,
-      "panels": [],
-      "title": "Prometheus Benchmark",
-      "type": "row"
-  },
-  {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 0,
-      "y": 2
-      },
-      "id": 40,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "prometheus_build_info{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{prometheus}} - {{version}} - {{revision}}",
-          "refId": "A"
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Prometheus Version",
-      "tooltip": {
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 8,
-      "y": 2
-      },
-      "id": 42,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "time() - process_start_time_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{prometheus}} - Uptime",
-          "refId": "A"
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Uptime",
-      "tooltip": {
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "dtdurations",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Max": "#e24d42",
-      "Open": "#508642"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "Total number open and maximum file descriptors of both release and PR",
-      "fill": 0,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 16,
-      "y": 2
-      },
-      "id": 41,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "process_max_fds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{prometheus}} - Max",
-          "refId": "A"
-      },
-      {
-          "expr": "process_open_fds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{prometheus}} - Open",
-          "refId": "B"
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "File Descriptors",
-      "tooltip": {
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833",
-      "Time series": "#70dbed"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "This graph indicates how many time series each instance holds",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 0,
-      "y": 9
-      },
-      "id": 3,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "prometheus_tsdb_head_series{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Time series",
-          "metric": "prometheus_local_storage_memory_series",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Head Time series",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "This graph shows the total number of active appender transactions",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 8,
-      "y": 9
-      },
-      "id": 26,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "prometheus_tsdb_head_active_appenders{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Head Appenders",
-          "metric": "prometheus_local_storage_memory_series",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Head Active Appenders",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "samples/s": "#e5a8e2"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "This graph shows the sample ingested per second",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 16,
-      "y": 9
-      },
-      "id": 1,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - samples/s",
-          "metric": "prometheus_local_storage_ingested_samples_total",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Samples Appended/s",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "short",
-          "label": "",
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833",
-      "To persist": "#9AC48A"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "Chunks are the collection of series of samples. The active series is known as the head chunk. Total of 120 samples are present in a chunk. This graph shows the total head chunks",
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 0,
-      "y": 16
-      },
-      "id": 2,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-      {
-          "alias": "/Max.*/",
-          "fill": 0
-      }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "prometheus_tsdb_head_chunks{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Chunks",
-          "metric": "prometheus_local_storage_memory_chunks",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Head Chunks",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "This graph shows chunks created per second",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 8,
-      "y": 16
-      },
-      "id": 4,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_tsdb_head_chunks_created_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Created",
-          "metric": "prometheus_local_storage_chunk_ops_total",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Head Chunks Created",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "ops",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833",
-      "Removed": "#e5ac0e"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "Head chunk is converted to chunk when it is filled with 120 samples. This graph shows the total number of head chunks created",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 16,
-      "y": 16
-      },
-      "id": 25,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_tsdb_head_chunks_removed_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Removed",
-          "metric": "prometheus_local_storage_chunk_ops_total",
-          "refId": "B",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Head Chunks Removed",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "ops",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max": "#447ebc",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833",
-      "Min": "#447ebc",
-      "Now": "#7eb26d"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "Plots of minimum and maximum timestamp of the head block in reference to current time",
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 0,
-      "y": 23
-      },
-      "id": 28,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-      {
-          "alias": "Max",
-          "fillBelowTo": "Min",
-          "lines": false
-      }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "prometheus_tsdb_head_min_time{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Min",
-          "metric": "prometheus_local_storage_series_chunks_persisted_count",
-          "refId": "A",
-          "step": 10
-      },
-      {
-          "expr": "time() * 1000",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "Now",
-          "refId": "C"
-      },
-      {
-          "expr": "prometheus_tsdb_head_max_time{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Max",
-          "metric": "prometheus_local_storage_series_chunks_persisted_count",
-          "refId": "B",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Head Time Range",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "decimals": null,
-          "format": "dateTimeAsIso",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "Average runtime of garbage collection in the head block",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 8,
-      "y": 23
-      },
-      "id": 29,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_tsdb_head_gc_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_head_gc_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - GC Time/s",
-          "metric": "prometheus_local_storage_series_chunks_persisted_count",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Avg Head GC Time/s",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "Total Number of currently loaded data blocks",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 16,
-      "y": 23
-      },
-      "id": 14,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-      {
-          "alias": "Queue length",
-          "yaxis": 2
-      }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "prometheus_tsdb_blocks_loaded{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Blocks Loaded",
-          "metric": "prometheus_local_storage_indexing_batch_sizes_sum",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Blocks Loaded",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Allocated bytes": "#F9BA8F",
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833",
-      "RSS": "#890F02"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "Total number of bytes allocated, even if freed",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 0,
-      "y": 30
-      },
-      "id": 7,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Allocated Bytes/s",
-          "metric": "go_memstats_alloc_bytes",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Allocations",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "bytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Failed Compactions": "#bf1b00",
-      "Failed Reloads": "#bf1b00",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "This graph shows the total number of times the database reloaded block data from disk",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 8,
-      "y": 30
-      },
-      "id": 30,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_tsdb_reloads_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Reloads",
-          "metric": "prometheus_local_storage_series_chunks_persisted_count",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "TSDB Reloads/s",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "none",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Failed Compactions": "#bf1b00",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833",
-      "{instance=\"demo.robustperception.io:9090\",job=\"prometheus\"}": "#bf1b00"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "This graph shows various tsdb related checks",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 16,
-      "y": 30
-      },
-      "id": 32,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_tsdb_wal_corruptions_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - WAL Corruptions",
-          "metric": "prometheus_local_storage_series_chunks_persisted_count",
-          "refId": "A",
-          "step": 10
-      },
-      {
-          "expr": "rate(prometheus_tsdb_reloads_failures_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Reload Failures",
-          "metric": "prometheus_local_storage_series_chunks_persisted_count",
-          "refId": "B",
-          "step": 10
-      },
-      {
-          "expr": "rate(prometheus_tsdb_head_series_not_found{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Head Series Not Found",
-          "metric": "prometheus_local_storage_series_chunks_persisted_count",
-          "refId": "C",
-          "step": 10
-      },
-      {
-          "expr": "rate(prometheus_tsdb_compactions_failed_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Compaction Failures",
-          "metric": "prometheus_local_storage_series_chunks_persisted_count",
-          "refId": "D",
-          "step": 10
-      },
-      {
-          "expr": "rate(prometheus_tsdb_retention_cutoffs_failures_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Retention Cutoff Failures",
-          "metric": "prometheus_local_storage_series_chunks_persisted_count",
-          "refId": "E",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "TSDB Problems/s",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "none",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Allocated bytes": "#F9BA8F",
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833",
-      "RSS": "#890F02"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "Total number of times the database cut off block data from disk",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 0,
-      "y": 37
-      },
-      "id": 8,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_tsdb_retention_cutoffs_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Retention Cutoffs",
-          "metric": "last",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Retention Cutoffs/s",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "none",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Failed Compactions": "#bf1b00",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "The latency distributions of fsync called by wal. High fsync duration (fsync_durations_seconds) indicates disk issues and might cause the cluster to be unstable",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 8,
-      "y": 37
-      },
-      "id": 31,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_tsdb_wal_fsync_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_wal_fsync_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Fsync Latency",
-          "metric": "prometheus_local_storage_series_chunks_persisted_count",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "WAL Fsync Latency",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Failed Compactions": "#bf1b00",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "WAL is used to get the backup when the prometheus server crashes. WAL stores the last 2hrs of data in memory. After that it has to truncate the data. So, this graph shows the latency of truncation",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 16,
-      "y": 37
-      },
-      "id": 65,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_tsdb_wal_truncate_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_wal_truncate_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Truncate Latency",
-          "metric": "prometheus_local_storage_series_chunks_persisted_count",
-          "refId": "B",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "WAL Truncate Latency",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 0,
-      "y": 44
-      },
-      "id": 35,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_tsdb_compaction_chunk_size_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) or rate(prometheus_tsdb_compaction_chunk_size_bytes_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Bytes/Sample",
-          "metric": "prometheus_local_storage_series_chunks_persisted_count",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "First Compaction, Avg Bytes/Sample",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "decimals": null,
-          "format": "bytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 8,
-      "y": 44
-      },
-      "id": 27,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_tsdb_compaction_chunk_range_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_range_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) or rate(prometheus_tsdb_compaction_chunk_range_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_range_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Chunk Time Range",
-          "metric": "prometheus_local_storage_series_chunks_persisted_count",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "First Compaction, Avg Chunk Time Range",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "decimals": null,
-          "format": "ms",
-          "label": "",
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 16,
-      "y": 44
-      },
-      "id": 34,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Chunk Samples",
-          "metric": "prometheus_local_storage_series_chunks_persisted_count",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "First Compaction, Avg Chunk Samples",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "none",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Failed Compactions": "#bf1b00",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "Total number of compactions that were executed for the partition",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 0,
-      "y": 51
-      },
-      "id": 19,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_tsdb_compactions_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Compactions",
-          "metric": "prometheus_local_storage_series_chunks_persisted_count",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Compactions/s",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "none",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "Average compactions that were executed for the partition",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 8,
-      "y": 51
-      },
-      "id": 33,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_tsdb_compaction_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}}",
-          "metric": "prometheus_local_storage_series_chunks_persisted_count",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Avg Compaction Time/s",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "decimals": 2,
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 16,
-      "y": 51
-      },
-      "id": 9,
-      "legend": {
-      "alignAsTable": false,
-      "avg": false,
-      "current": false,
-      "hideEmpty": false,
-      "max": false,
-      "min": false,
-      "rightSide": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "irate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Irate",
-          "metric": "prometheus_local_storage_ingested_samples_total",
-          "refId": "A",
-          "step": 10
-      },
-      {
-          "expr": "rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[5m])",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - 5m rate",
-          "metric": "prometheus_local_storage_ingested_samples_total",
-          "refId": "B",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "CPU",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": [
-          "avg"
-      ]
-      },
-      "yaxes": [
-      {
-          "format": "none",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Allocated bytes": "#7EB26D",
-      "Allocated bytes - 1m max": "#BF1B00",
-      "Allocated bytes - 1m min": "#BF1B00",
-      "Allocated bytes - 5m max": "#BF1B00",
-      "Allocated bytes - 5m min": "#BF1B00",
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833",
-      "RSS": "#447EBC"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "decimals": null,
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 0,
-      "y": 58
-      },
-      "id": 6,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-      {
-          "alias": "/-/",
-          "fill": 0
-      }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - RSS",
-          "metric": "process_resident_memory_bytes",
-          "refId": "B",
-          "step": 10
-      },
-      {
-          "expr": "prometheus_local_storage_target_heap_size_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Target heap size",
-          "metric": "go_memstats_alloc_bytes",
-          "refId": "D",
-          "step": 10
-      },
-      {
-          "expr": "go_memstats_next_gc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Next GC",
-          "metric": "go_memstats_next_gc_bytes",
-          "refId": "C",
-          "step": 10
-      },
-      {
-          "expr": "go_memstats_alloc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Allocated",
-          "metric": "go_memstats_alloc_bytes",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Memory",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "bytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "",
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 8,
-      "y": 58
-      },
-      "id": 38,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - {{handler}}",
-          "metric": "prometheus_local_storage_memory_chunkdescs",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "HTTP requests/s",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "reqps",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "",
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 16,
-      "y": 58
-      },
-      "id": 37,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - {{handler}}",
-          "metric": "prometheus_local_storage_memory_chunkdescs",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Avg HTTP request latency",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "Time spent in prepare_time mode, per second",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 0,
-      "y": 65
-      },
-      "id": 64,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"prepare_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"prepare_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}}",
-          "metric": "prometheus_local_storage_memory_chunkdescs",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Avg query engine timings/s - prepare_time",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "Average Time spent in inner_eval mode, per second",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 8,
-      "y": 65
-      },
-      "id": 24,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"inner_eval\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"inner_eval\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}}",
-          "metric": "prometheus_local_storage_memory_chunkdescs",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Avg query engine timings/s - inner_eval",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "Time spent in queue_time mode, per second",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 16,
-      "y": 65
-      },
-      "id": 63,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"queue_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"queue_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}}",
-          "metric": "prometheus_local_storage_memory_chunkdescs",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Avg query engine timings/s - queue_time",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "Average Time spent in result_sort mode, per second",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 0,
-      "y": 72
-      },
-      "id": 62,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"result_sort\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"result_sort\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}}",
-          "metric": "prometheus_local_storage_memory_chunkdescs",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Avg query engine timings/s - result_sort",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 8,
-      "y": 72
-      },
-      "id": 22,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_rule_group_iterations_missed_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])  ",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Rule group missed",
-          "metric": "prometheus_local_storage_memory_chunkdescs",
-          "refId": "B",
-          "step": 10
-      },
-      {
-          "expr": "rate(prometheus_rule_evaluation_failures_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Rule evals failed",
-          "metric": "prometheus_local_storage_memory_chunkdescs",
-          "refId": "C",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Rule group evaluation problems/s",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 16,
-      "y": 72
-      },
-      "id": 23,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "rate(prometheus_rule_group_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Rule evaluation duration",
-          "metric": "prometheus_local_storage_memory_chunkdescs",
-          "refId": "A",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Evaluation time of rule groups/s",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-      "aliasColors": {
-      "Chunks": "#1F78C1",
-      "Chunks to persist": "#508642",
-      "Interval": "#890f02",
-      "Last Duration": "#f9934e",
-      "Max chunks": "#052B51",
-      "Max to persist": "#3F6833"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus-meta",
-      "description": "Rule group describe the Prometheus alerts. These graph consist of two rules:\n- prometheus_rule_group_interval_seconds:  When the first notification was sent, wait for 'group_interval' to send a batch of new alerts that started firing for that group.\n- prometheus_rule_group_last_duration_seconds: It shows the last duration of each one of your groups in seconds\n",
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 0,
-      "y": 79
-      },
-      "id": 43,
-      "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "repeat": "RuleGroup",
-      "repeatDirection": "h",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-      {
-          "expr": "prometheus_rule_group_interval_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",rule_group=~\"$RuleGroup\"}\n",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Interval",
-          "metric": "prometheus_local_storage_memory_chunkdescs",
-          "refId": "A",
-          "step": 10
-      },
-      {
-          "expr": "prometheus_rule_group_last_duration_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",rule_group=~\"$RuleGroup\"}\n",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{prometheus}} - Last Duration",
-          "metric": "prometheus_local_storage_memory_chunkdescs",
-          "refId": "B",
-          "step": 10
-      }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Rule Group: $RuleGroup",
-      "tooltip": {
-      "msResolution": false,
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-      },
-      "yaxes": [
-      {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-      },
-      {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-      }
-      ]
-  },
-  {
-  "aliasColors": {},
-  "bars": false,
-  "dashLength": 10,
-  "dashes": false,
-  "description": "This graph shows the highest and lowest TSDB watermarks. The highest watermark represents the latest appender and the lowest watermark represents the oldest appender",
-  "fill": 0,
-  "fillGradient": 0,
-  "gridPos": {
-    "h": 7,
-    "w": 8,
-    "x": 8,
-    "y": 79
-  },
-  "id": 67,
-  "legend": {
-    "avg": false,
-    "current": false,
-    "max": false,
-    "min": false,
-    "show": true,
-    "total": false,
-    "values": false
-  },
-  "lines": true,
-  "linewidth": 1,
-  "nullPointMode": "null",
-  "options": {
-    "dataLinks": []
-  },
-  "percentage": false,
-  "pointradius": 2,
-  "points": false,
-  "renderer": "flot",
-  "seriesOverrides": [],
-  "spaceLength": 10,
-  "stack": false,
-  "steppedLine": false,
-  "targets": [
-    {
-      "expr": "prometheus_tsdb_isolation_low_watermark{namespace='prombench-${prNumber}'}",
-      "legendFormat": "{{prometheus}} - low watermark",
-      "refId": "A"
-    },
-    {
-      "expr": "prometheus_tsdb_isolation_high_watermark{namespace='prombench-${prNumber}'}",
-      "interval": "",
-      "legendFormat": "{{prometheus}} - high watermark",
-      "refId": "B"
-    }
-  ],
-  "thresholds": [],
-  "timeFrom": null,
-  "timeRegions": [],
-  "timeShift": null,
-  "title": "TSDB Isolation Watermarks",
-  "tooltip": {
-    "shared": true,
-    "sort": 0,
-    "value_type": "individual"
-  },
-  "type": "graph",
-  "xaxis": {
-    "buckets": null,
-    "mode": "time",
-    "name": null,
-    "show": true,
-    "values": []
-  },
-  "yaxes": [
-    {
-      "format": "short",
-      "label": null,
-      "logBase": 1,
-      "max": null,
-      "min": null,
-      "show": true
-    },
-    {
-      "format": "short",
-      "label": null,
-      "logBase": 1,
-      "max": null,
-      "min": null,
-      "show": true
-    }
-  ],
-  "yaxis": {
-    "align": false,
-    "alignLevel": null
-  }
-  },
-  {
-    "aliasColors": {},
-    "bars": false,
-    "dashLength": 10,
-    "dashes": false,
-    "description": "This graph the difference of highest and lowest of TSDB watermark and also shows the size of isolation linked-chain",
-    "fill": 0,
-    "fillGradient": 0,
-    "gridPos": {
-      "h": 7,
-      "w": 8,
-      "x": 16,
-      "y": 79
-    },
-    "id": 68,
-    "legend": {
-      "avg": false,
-      "current": false,
-      "max": false,
-      "min": false,
-      "show": true,
-      "total": false,
-      "values": false
-    },
-    "lines": true,
-    "linewidth": 1,
-    "nullPointMode": "null",
-    "options": {
-      "dataLinks": []
-    },
-    "percentage": false,
-    "pointradius": 2,
-    "points": false,
-    "renderer": "flot",
-    "seriesOverrides": [],
-    "spaceLength": 10,
-    "stack": false,
-    "steppedLine": false,
-    "targets": [
-      {
-        "expr": "prometheus_tsdb_isolation_high_watermark{namespace='prombench-${prNumber}'} - prometheus_tsdb_isolation_low_watermark{namespace='prombench-${prNumber}'}",
-        "legendFormat": "{{prometheus}}",
-        "refId": "A"
-      }
-    ],
-    "thresholds": [],
-    "timeFrom": null,
-    "timeRegions": [],
-    "timeShift": null,
-    "title": "TSDB Isolation Watermarks Difference",
-    "tooltip": {
-      "shared": true,
-      "sort": 0,
-      "value_type": "individual"
-    },
-    "type": "graph",
-    "xaxis": {
-      "buckets": null,
-      "mode": "time",
-      "name": null,
-      "show": true,
-      "values": []
-    },
-    "yaxes": [
-      {
-        "format": "short",
-        "label": null,
-        "logBase": 1,
-        "max": null,
-        "min": null,
-        "show": true
-      },
-      {
-        "format": "short",
-        "label": null,
-        "logBase": 1,
-        "max": null,
-        "min": null,
-        "show": true
-      }
-    ],
-    "yaxis": {
-      "align": false,
-      "alignLevel": null
-    }
-  }
-  ],
-  "refresh": false,
-  "schemaVersion": 16,
-  "style": "dark",
-  "templating": {
-    "list": [
-      {
-        "allValue": null,
-        "current": {},
-        "datasource": "prometheus-meta",
-        "hide": 2,
-        "includeAll": true,
-        "label": null,
-        "multi": false,
-        "name": "RuleGroup",
-        "options": [],
-        "query": "prometheus_rule_group_last_duration_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-        "refresh": 2,
-        "regex": ".*rule_group=\"(.*?)\".*",
-        "sort": 1,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {},
-        "datasource": "prometheus-meta",
-        "definition": "label_values(namespace)",
-        "description": "PR number",
-        "hide": 0,
-        "includeAll": false,
-        "multi": false,
-        "name": "prNumber",
-        "options": [],
-        "query": {
-          "query": "label_values(namespace)",
-          "refId": "StandardVariableQuery"
+    "__requires": [
+        {
+            "type": "grafana",
+            "id": "grafana",
+            "name": "Grafana",
+            "version": "5.0.0"
         },
-        "refresh": 1,
-        "regex": "prombench-(\\d+)",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      }
-    ]
-  },
-  "time": {
-    "from": "now-30m",
-    "to": "now"
-  },
-  "timepicker": {
-    "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
+        {
+            "type": "datasource",
+            "id": "prometheus",
+            "name": "Prometheus",
+            "version": "5.0.0"
+        }
     ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
-    ]
-  },
-  "timezone": "browser",
-  "title": "Prombench",
-  "uid": "7gmLoNDmz",
-  "version": 3
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            }
+        ]
+    },
+    "description": "Metrics useful for benchmarking and loadtesting Prometheus itself. Designed primarily for Prometheus 3.x.",
+    "tags": [
+        "benchmark",
+        "node-metrics"
+    ],
+    "editable": true,
+    "gnetId": 6725,
+    "graphTooltip": 1,
+    "id": null,
+    "links": [],
+    "panels": [
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 69,
+            "panels": [],
+            "title": "Acceptance: 💾 Memory",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "description": "Delta of number of bytes allocated per second (go_memstats_alloc_bytes_total), even if freed. PR minus Reference, so negative values indicate how much less PR allocates.\n\n10m lower than our periodic scrape load scale ups and downs cycles (~30m interval) but large enough to hide noise.",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "dashed"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 0
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 9,
+                "w": 16,
+                "x": 0,
+                "y": 1
+            },
+            "id": 70,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "mean",
+                        "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true,
+                    "sortBy": "Name",
+                    "sortDesc": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\"}[10m])) - sum(rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\"}[10m]))",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "legendFormat": "PR vs Ref - Allocated Bytes/s ",
+                    "metric": "go_memstats_alloc_bytes",
+                    "range": true,
+                    "refId": "A",
+                    "step": 10
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\"}[10m])",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "legendFormat": "{{prometheus}} - Allocated Bytes/s ",
+                    "metric": "go_memstats_alloc_bytes",
+                    "range": true,
+                    "refId": "B",
+                    "step": 10
+                }
+            ],
+            "title": "rate[10m] Go Heap Allocations (PR vs Ref: smaller, ideally negative, is better)",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "description": "Ref % of Delta of number of bytes allocated per second (go_memstats_alloc_bytes_total), even if freed. PR minus Reference, so negative values indicate how much less PR allocates.\n",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 0
+                            }
+                        ]
+                    },
+                    "unit": "percentunit"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 9,
+                "w": 8,
+                "x": 16,
+                "y": 1
+            },
+            "id": 75,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "mean"
+                    ],
+                    "fields": "/^PR vs Ref \\- Allocated Bytes/s $/",
+                    "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+            },
+            "pluginVersion": "11.0.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "(sum(rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\"}[10m])) - sum(rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\"}[10m]))) / sum(rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\"}[10m]))",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "legendFormat": "PR vs Ref - Allocated Bytes/s ",
+                    "metric": "go_memstats_alloc_bytes",
+                    "range": true,
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "description": "Delta of number of avg bytes allocated within 30m windows for RSS and heap.\n\nPR minus Reference, so negative values indicate how much less PR allocates.\n",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineStyle": {
+                            "fill": "solid"
+                        },
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "dashed"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 0
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 10,
+                "w": 16,
+                "x": 0,
+                "y": 10
+            },
+            "id": 71,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "mean",
+                        "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(avg_over_time(go_memstats_alloc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\"}[10m])) - sum(avg_over_time(go_memstats_alloc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\", prometheus!~\"test-pr.*\"}[10m]))",
+                    "intervalFactor": 2,
+                    "legendFormat": "PR vs Ref - Allocated (heap)",
+                    "metric": "go_memstats_alloc_bytes",
+                    "range": true,
+                    "refId": "A",
+                    "step": 10
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(avg_over_time(process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\"}[10m])) - sum(avg_over_time(process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\", prometheus!~\"test-pr.*\"}[10m]))",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "legendFormat": "PR vs Ref - RSS",
+                    "metric": "process_resident_memory_bytes",
+                    "range": true,
+                    "refId": "C",
+                    "step": 10
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "avg_over_time(process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\"}[10m])",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "legendFormat": "{{prometheus}}- RSS",
+                    "metric": "process_resident_memory_bytes",
+                    "range": true,
+                    "refId": "B",
+                    "step": 10
+                }
+            ],
+            "title": "avg[10m] Allocations (PR vs Ref: smaller, ideally negative, is better)",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "description": "Ref % of Delta of number of avg bytes allocated within 30m windows for RSS and heap.\n\nPR minus Reference, so negative values indicate how much less PR allocates.\n",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 0
+                            }
+                        ]
+                    },
+                    "unit": "percentunit"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 10,
+                "w": 8,
+                "x": 16,
+                "y": 10
+            },
+            "id": 76,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+            },
+            "pluginVersion": "11.0.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "(sum(avg_over_time(go_memstats_alloc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\"}[10m])) - sum(avg_over_time(go_memstats_alloc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\", prometheus!~\"test-pr.*\"}[10m])))/  sum(avg_over_time(go_memstats_alloc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\", prometheus!~\"test-pr.*\"}[10m]))",
+                    "intervalFactor": 2,
+                    "legendFormat": "PR vs Ref - Allocated (heap)",
+                    "metric": "go_memstats_alloc_bytes",
+                    "range": true,
+                    "refId": "A",
+                    "step": 10
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "(sum(avg_over_time(process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\"}[10m])) - sum(avg_over_time(process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\", prometheus!~\"test-pr.*\"}[10m]))) / sum(avg_over_time(process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\", prometheus!~\"test-pr.*\"}[10m]))",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "legendFormat": "PR vs Ref - RSS",
+                    "metric": "process_resident_memory_bytes",
+                    "range": true,
+                    "refId": "C",
+                    "step": 10
+                }
+            ],
+            "type": "stat"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 20
+            },
+            "id": 74,
+            "panels": [],
+            "title": "Acceptance: 💻 CPU ",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "description": "Delta of per second process CPU usage.\n\nPR minus Reference, so negative values indicate how much less the PR use CPU.\n",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "dashed"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 0
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 16,
+                "x": 0,
+                "y": 21
+            },
+            "id": 72,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "mean",
+                        "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\"}[10m])) - sum(rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\"}[10m]))",
+                    "intervalFactor": 2,
+                    "legendFormat": "PR vs Ref - rate",
+                    "metric": "prometheus_local_storage_ingested_samples_total",
+                    "range": true,
+                    "refId": "B",
+                    "step": 10
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "legendFormat": "{{prometheus}} - rate",
+                    "metric": "prometheus_local_storage_ingested_samples_total",
+                    "range": true,
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "title": "rate[10m] CPU (PR vs Ref: smaller, ideally negative, is better)",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "description": "Ref % of Delta of per second process CPU usage.\n\nPR minus Reference, so negative values indicate how much less the PR use CPU.\n",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 0
+                            }
+                        ]
+                    },
+                    "unit": "percentunit"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 21
+            },
+            "id": 77,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+            },
+            "pluginVersion": "11.0.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "(sum(rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\"}[10m])) - sum(rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\"}[10m]))) / sum(rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\"}[10m]))",
+                    "intervalFactor": 2,
+                    "legendFormat": "PR vs Ref - rate",
+                    "metric": "prometheus_local_storage_ingested_samples_total",
+                    "range": true,
+                    "refId": "B",
+                    "step": 10
+                }
+            ],
+            "type": "stat"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 29
+            },
+            "id": 86,
+            "panels": [],
+            "title": "Acceptance: 🧭 Query Latency",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "dashed"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "semi-dark-red",
+                                "value": 0
+                            }
+                        ]
+                    },
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 9,
+                "w": 16,
+                "x": 0,
+                "y": 30
+            },
+            "id": 85,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "mean",
+                        "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]))  - sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "legendFormat": "PR vs Ref - {{handler}}",
+                    "metric": "prometheus_local_storage_memory_chunkdescs",
+                    "range": true,
+                    "refId": "A",
+                    "step": 10
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",handler=\"/api/v1/query\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",handler=\"/api/v1/query\"}[10m])",
+                    "hide": false,
+                    "instant": false,
+                    "legendFormat": "{{prometheus}} - {{handler}}",
+                    "range": true,
+                    "refId": "B"
+                }
+            ],
+            "title": "rate[10m] Query Instant Latency (PR vs Ref: smaller, ideally negative, is better)",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "description": "Ref % of Delta of Query instant latency\n\nPR minus Reference, so negative values indicate how much less the PR use CPU.\n",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 0
+                            }
+                        ]
+                    },
+                    "unit": "percentunit"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 9,
+                "w": 8,
+                "x": 16,
+                "y": 30
+            },
+            "id": 88,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+            },
+            "pluginVersion": "11.0.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "(sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]))  - sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]))) / sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]))",
+                    "intervalFactor": 2,
+                    "legendFormat": "PR vs Ref - {{handler}}",
+                    "metric": "prometheus_local_storage_ingested_samples_total",
+                    "range": true,
+                    "refId": "B",
+                    "step": 10
+                }
+            ],
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "dashed"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "semi-dark-red",
+                                "value": 0
+                            }
+                        ]
+                    },
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 16,
+                "x": 0,
+                "y": 39
+            },
+            "id": 87,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "mean",
+                        "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]))  - sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]))",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "legendFormat": "PR vs Ref - {{handler}}",
+                    "metric": "prometheus_local_storage_memory_chunkdescs",
+                    "range": true,
+                    "refId": "A",
+                    "step": 10
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",handler=\"/api/v1/query_range\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",handler=\"/api/v1/query_range\"}[10m])",
+                    "hide": false,
+                    "instant": false,
+                    "legendFormat": "{{prometheus}} - {{handler}}",
+                    "range": true,
+                    "refId": "B"
+                }
+            ],
+            "title": "rate[10m] Query Range Latency (PR vs Ref: smaller, ideally negative, is better)",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "description": "Ref % of Delta of Query range latency\n\nPR minus Reference, so negative values indicate how much less the PR use CPU.\n",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 0
+                            }
+                        ]
+                    },
+                    "unit": "percentunit"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 39
+            },
+            "id": 89,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+            },
+            "pluginVersion": "11.0.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "(sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]))  - sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]))) / sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]))",
+                    "intervalFactor": 2,
+                    "legendFormat": "PR vs Ref - {{handler}}",
+                    "metric": "prometheus_local_storage_ingested_samples_total",
+                    "range": true,
+                    "refId": "B",
+                    "step": 10
+                }
+            ],
+            "type": "stat"
+        },
+        {
+            "collapsed": true,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 47
+            },
+            "id": 79,
+            "panels": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 0,
+                        "y": 30
+                    },
+                    "id": 40,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "prometheus_build_info{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "legendFormat": "{{prometheus}} - {{version}} - {{revision}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Prometheus Version",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "dtdurations"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 8,
+                        "y": 30
+                    },
+                    "id": 42,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "time() - process_start_time_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "legendFormat": "{{prometheus}} - Uptime",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Uptime",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "This graph shows the sample ingested per second",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 16,
+                        "y": 30
+                    },
+                    "id": 1,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - samples/s",
+                            "metric": "prometheus_local_storage_ingested_samples_total",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Samples Appended/s",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "This graph indicates how many time series each instance holds",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 0,
+                        "y": 37
+                    },
+                    "id": 3,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "prometheus_tsdb_head_series{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Time series",
+                            "metric": "prometheus_local_storage_memory_series",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Head Time series",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "This graph shows the total number of times the database reloaded block data from disk",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "none"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 8,
+                        "y": 37
+                    },
+                    "id": 30,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_tsdb_reloads_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Reloads",
+                            "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "TSDB Reloads/s",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "Total Number of currently loaded data blocks",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 16,
+                        "y": 37
+                    },
+                    "id": 14,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "prometheus_tsdb_blocks_loaded{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Blocks Loaded",
+                            "metric": "prometheus_local_storage_indexing_batch_sizes_sum",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Blocks Loaded",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "This graph shows various tsdb related checks",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "none"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 0,
+                        "y": 44
+                    },
+                    "id": 32,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_tsdb_wal_corruptions_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - WAL Corruptions",
+                            "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                            "refId": "A",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_tsdb_reloads_failures_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Reload Failures",
+                            "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                            "refId": "B",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_tsdb_head_series_not_found{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Head Series Not Found",
+                            "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                            "refId": "C",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_tsdb_compactions_failed_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Compaction Failures",
+                            "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                            "refId": "D",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_tsdb_retention_cutoffs_failures_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Retention Cutoff Failures",
+                            "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                            "refId": "E",
+                            "step": 10
+                        }
+                    ],
+                    "title": "TSDB Problems/s",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "Total number of compactions that were executed for the partition",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "none"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 8,
+                        "y": 44
+                    },
+                    "id": 19,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_tsdb_compactions_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Compactions",
+                            "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Compactions/s",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "Step 61s is to avoid aliasing (max interval of our queries is 1m)",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 0,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 16,
+                        "y": 44
+                    },
+                    "id": 38,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "editorMode": "code",
+                            "expr": "rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                            "format": "time_series",
+                            "interval": "61s",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - {{handler}}",
+                            "metric": "prometheus_local_storage_memory_chunkdescs",
+                            "range": true,
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "HTTP requests/s",
+                    "type": "timeseries"
+                }
+            ],
+            "title": "Functional Check",
+            "type": "row"
+        },
+        {
+            "collapsed": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 48
+            },
+            "id": 45,
+            "panels": [],
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "refId": "A"
+                }
+            ],
+            "title": "Performance Details",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "description": "Total number of bytes allocated, even if freed",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 49
+            },
+            "id": 7,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[5m])",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "legendFormat": "{{prometheus}} - Allocated Bytes/s",
+                    "metric": "go_memstats_alloc_bytes",
+                    "range": true,
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "title": "Allocations",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "description": "Total number of objects allocated",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 49
+            },
+            "id": 84,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(go_gc_heap_allocs_objects_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "legendFormat": "{{prometheus}}",
+                    "metric": "go_memstats_alloc_bytes",
+                    "range": true,
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "title": "Objects allocated per second",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 49
+            },
+            "id": 83,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "go_gc_heap_objects_objects{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\"}",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{prometheus}}",
+                    "metric": "prometheus_local_storage_ingested_samples_total",
+                    "range": true,
+                    "refId": "B",
+                    "step": 10
+                }
+            ],
+            "title": "Live objects on heap",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                }
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 56
+            },
+            "id": 6,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "expr": "process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{prometheus}} - RSS",
+                    "metric": "process_resident_memory_bytes",
+                    "refId": "B",
+                    "step": 10
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "expr": "prometheus_local_storage_target_heap_size_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{prometheus}} - Target heap size",
+                    "metric": "go_memstats_alloc_bytes",
+                    "refId": "D",
+                    "step": 10
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "expr": "go_memstats_next_gc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{prometheus}} - Next GC",
+                    "metric": "go_memstats_next_gc_bytes",
+                    "refId": "C",
+                    "step": 10
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "expr": "go_memstats_alloc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{prometheus}} - Allocated",
+                    "metric": "go_memstats_alloc_bytes",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "title": "Memory",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                }
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 56
+            },
+            "id": 9,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "expr": "irate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{prometheus}} - Irate",
+                    "metric": "prometheus_local_storage_ingested_samples_total",
+                    "refId": "A",
+                    "step": 10
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "expr": "rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[5m])",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{prometheus}} - 5m rate",
+                    "metric": "prometheus_local_storage_ingested_samples_total",
+                    "refId": "B",
+                    "step": 10
+                }
+            ],
+            "title": "CPU",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "s"
+                }
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 56
+            },
+            "id": 37,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                    "format": "time_series",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{prometheus}} - {{handler}}",
+                    "metric": "prometheus_local_storage_memory_chunkdescs",
+                    "range": true,
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "title": "Avg HTTP request latency",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                }
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 63
+            },
+            "id": 82,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(go_gc_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\"}[10m]) / rate(go_gc_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\"}[10m]) ",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{prometheus}} - 10m rate",
+                    "metric": "prometheus_local_storage_ingested_samples_total",
+                    "range": true,
+                    "refId": "B",
+                    "step": 10
+                }
+            ],
+            "title": "Average GC duration seconds",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 63
+            },
+            "id": 81,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(go_gc_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\"}[10m]) *60",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{prometheus}} - 10m rate",
+                    "metric": "prometheus_local_storage_ingested_samples_total",
+                    "range": true,
+                    "refId": "B",
+                    "step": 10
+                }
+            ],
+            "title": "GC runs per minute",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "description": "Average compactions that were executed for the partition",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 70
+            },
+            "id": 33,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "expr": "rate(prometheus_tsdb_compaction_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "legendFormat": "{{prometheus}}",
+                    "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "title": "Avg Compaction Time/s",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "description": "WAL is used to get the backup when the prometheus server crashes. WAL stores the last 2hrs of data in memory. After that it has to truncate the data. So, this graph shows the latency of truncation",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 70
+            },
+            "id": 65,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "expr": "rate(prometheus_tsdb_wal_truncate_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_wal_truncate_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{prometheus}} - Truncate Latency",
+                    "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                    "refId": "B",
+                    "step": 10
+                }
+            ],
+            "title": "WAL Truncate Latency",
+            "type": "timeseries"
+        },
+        {
+            "collapsed": true,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P86B77AEF8F12A5FA"
+            },
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 77
+            },
+            "id": 47,
+            "panels": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "bytes"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 9,
+                        "w": 12,
+                        "x": 0,
+                        "y": 78
+                    },
+                    "id": 51,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "mean",
+                                "lastNotNull",
+                                "max",
+                                "min"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "node_memory_MemTotal_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "hide": false,
+                            "intervalFactor": 1,
+                            "legendFormat": "{{node}} - Total memory",
+                            "refId": "E"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "node_memory_MemTotal_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"} - node_memory_MemFree_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"} - node_memory_Buffers_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"} - node_memory_Cached_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "legendFormat": "{{node}} - Used",
+                            "refId": "A"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "node_memory_Buffers_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "legendFormat": "{{node}} - Buffers",
+                            "refId": "B"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "node_memory_Cached_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "legendFormat": "{{node}} - Cached",
+                            "refId": "C"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "node_memory_MemFree_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "legendFormat": "{{node}} - Free",
+                            "refId": "D"
+                        }
+                    ],
+                    "title": "Memory",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "percentunit"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 9,
+                        "w": 12,
+                        "x": 12,
+                        "y": 78
+                    },
+                    "id": 53,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "irate(node_disk_io_time_seconds_total{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\",device!~'^(md\\\\\\\\d+$|dm-)'}[5m])",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "legendFormat": "{{node}} - {{device}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Disk I/O Utilisation",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 9,
+                        "w": 12,
+                        "x": 0,
+                        "y": 87
+                    },
+                    "id": 57,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "irate(node_context_switches_total{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}[5m])",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "legendFormat": "{{node}} - Context Switches",
+                            "refId": "A"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "irate(node_intr_total{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}[5m])",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "legendFormat": "{{node}} - Interrupts",
+                            "refId": "B"
+                        }
+                    ],
+                    "title": "Context Switches / Interrupts",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "Disk space used of all filesystems mounted",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "max": 100,
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "percent"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 9,
+                        "w": 12,
+                        "x": 12,
+                        "y": 87
+                    },
+                    "id": 61,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "mean",
+                                "lastNotNull",
+                                "max",
+                                "min"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "100 - ((node_filesystem_avail_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\",device!~'rootfs'} * 100) / node_filesystem_size_bytes{node=~'(test+).*',device!~'rootfs'})",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "legendFormat": "{{node}} - {{mountpoint}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Disk Space Used Basic",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 9,
+                        "w": 12,
+                        "x": 0,
+                        "y": 96
+                    },
+                    "id": 59,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "mean",
+                                "lastNotNull",
+                                "max",
+                                "min"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "node_load1{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "legendFormat": "{{node}} - Load 1m",
+                            "refId": "A"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "node_load5{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "legendFormat": "{{node}} - Load 5m",
+                            "refId": "B"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "node_load15{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "legendFormat": "{{node}} - Load 15m",
+                            "refId": "C"
+                        }
+                    ],
+                    "title": "System Load",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "percentunit"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 9,
+                        "w": 12,
+                        "x": 12,
+                        "y": 96
+                    },
+                    "id": 55,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "1 - node_filesystem_free_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\",fstype!='rootfs',mountpoint!~'/(run|var).*',mountpoint!=''} / node_filesystem_size_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "legendFormat": "{{node}} - {{mountpoint}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Filesystem Fullness",
+                    "type": "timeseries"
+                }
+            ],
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "refId": "A"
+                }
+            ],
+            "title": "Node Metrics",
+            "type": "row"
+        },
+        {
+            "collapsed": true,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 78
+            },
+            "id": 80,
+            "panels": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "Time spent in queue_time mode, per second",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 0,
+                        "y": 89
+                    },
+                    "id": 63,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"queue_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"queue_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                            "format": "time_series",
+                            "hide": false,
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}}",
+                            "metric": "prometheus_local_storage_memory_chunkdescs",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Avg query engine timings/s - queue_time",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "Average Time spent in inner_eval mode, per second",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 8,
+                        "y": 89
+                    },
+                    "id": 24,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"inner_eval\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"inner_eval\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                            "format": "time_series",
+                            "hide": false,
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}}",
+                            "metric": "prometheus_local_storage_memory_chunkdescs",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Avg query engine timings/s - inner_eval",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "Average Time spent in result_sort mode, per second",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 16,
+                        "y": 89
+                    },
+                    "id": 62,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"result_sort\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"result_sort\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                            "format": "time_series",
+                            "hide": false,
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}}",
+                            "metric": "prometheus_local_storage_memory_chunkdescs",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Avg query engine timings/s - result_sort",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "Time spent in prepare_time mode, per second",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 0,
+                        "y": 96
+                    },
+                    "id": 64,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "editorMode": "code",
+                            "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"prepare_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"prepare_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                            "format": "time_series",
+                            "hide": false,
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}}",
+                            "metric": "prometheus_local_storage_memory_chunkdescs",
+                            "range": true,
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Avg query engine timings/s - prepare_time",
+                    "type": "timeseries"
+                }
+            ],
+            "title": "Query Latency: Details",
+            "type": "row"
+        },
+        {
+            "collapsed": true,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 79
+            },
+            "id": 78,
+            "panels": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "Total number open and maximum file descriptors of both release and PR",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 0,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 0,
+                        "y": 69
+                    },
+                    "id": 41,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "process_max_fds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "legendFormat": "{{prometheus}} - Max",
+                            "refId": "A"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "process_open_fds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "legendFormat": "{{prometheus}} - Open",
+                            "refId": "B"
+                        }
+                    ],
+                    "title": "File Descriptors",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "Chunks are the collection of series of samples. The active series is known as the head chunk. Total of 120 samples are present in a chunk. This graph shows the total head chunks",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 0,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 8,
+                        "y": 69
+                    },
+                    "id": 2,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "prometheus_tsdb_head_chunks{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Chunks",
+                            "metric": "prometheus_local_storage_memory_chunks",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Head Chunks",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "Average runtime of garbage collection in the head block",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 16,
+                        "y": 69
+                    },
+                    "id": 29,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_tsdb_head_gc_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_head_gc_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - GC Time/s",
+                            "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Avg Head GC Time/s",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "Plots of minimum and maximum timestamp of the head block in reference to current time",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 35,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "dateTimeAsIso"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 0,
+                        "y": 76
+                    },
+                    "id": 28,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "prometheus_tsdb_head_min_time{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Min",
+                            "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                            "refId": "A",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "time() * 1000",
+                            "format": "time_series",
+                            "hide": false,
+                            "intervalFactor": 2,
+                            "legendFormat": "Now",
+                            "refId": "C"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "prometheus_tsdb_head_max_time{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Max",
+                            "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                            "refId": "B",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Head Time Range",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "This graph shows the total number of active appender transactions",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 8,
+                        "y": 76
+                    },
+                    "id": 26,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "prometheus_tsdb_head_active_appenders{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Head Appenders",
+                            "metric": "prometheus_local_storage_memory_series",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Head Active Appenders",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "Rule group describe the Prometheus alerts. These graph consist of two rules:\n- prometheus_rule_group_interval_seconds:  When the first notification was sent, wait for 'group_interval' to send a batch of new alerts that started firing for that group.\n- prometheus_rule_group_last_duration_seconds: It shows the last duration of each one of your groups in seconds\n",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 0,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 16,
+                        "y": 76
+                    },
+                    "id": 43,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "repeat": "RuleGroup",
+                    "repeatDirection": "h",
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "prometheus_rule_group_interval_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",rule_group=~\"$RuleGroup\"}\n",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Interval",
+                            "metric": "prometheus_local_storage_memory_chunkdescs",
+                            "refId": "A",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "prometheus_rule_group_last_duration_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",rule_group=~\"$RuleGroup\"}\n",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Last Duration",
+                            "metric": "prometheus_local_storage_memory_chunkdescs",
+                            "refId": "B",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Rule Group: $RuleGroup",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "Total number of times the database cut off block data from disk",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "none"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 0,
+                        "y": 83
+                    },
+                    "id": 8,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_tsdb_retention_cutoffs_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Retention Cutoffs",
+                            "metric": "last",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Retention Cutoffs/s",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 8,
+                        "y": 83
+                    },
+                    "id": 22,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_rule_group_iterations_missed_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])  ",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Rule group missed",
+                            "metric": "prometheus_local_storage_memory_chunkdescs",
+                            "refId": "B",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_rule_evaluation_failures_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Rule evals failed",
+                            "metric": "prometheus_local_storage_memory_chunkdescs",
+                            "refId": "C",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Rule group evaluation problems/s",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "ms"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 16,
+                        "y": 83
+                    },
+                    "id": 27,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_tsdb_compaction_chunk_range_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_range_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) or rate(prometheus_tsdb_compaction_chunk_range_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_range_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Chunk Time Range",
+                            "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "First Compaction, Avg Chunk Time Range",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "This graph shows the highest and lowest TSDB watermarks. The highest watermark represents the latest appender and the lowest watermark represents the oldest appender",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 0,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 0,
+                        "y": 90
+                    },
+                    "id": 67,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "prometheus_tsdb_isolation_low_watermark{namespace='prombench-${prNumber}'}",
+                            "legendFormat": "{{prometheus}} - low watermark",
+                            "refId": "A"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "prometheus_tsdb_isolation_high_watermark{namespace='prombench-${prNumber}'}",
+                            "interval": "",
+                            "legendFormat": "{{prometheus}} - high watermark",
+                            "refId": "B"
+                        }
+                    ],
+                    "title": "TSDB Isolation Watermarks",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 8,
+                        "y": 90
+                    },
+                    "id": 23,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_rule_group_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Rule evaluation duration",
+                            "metric": "prometheus_local_storage_memory_chunkdescs",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Evaluation time of rule groups/s",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "none"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 16,
+                        "y": 90
+                    },
+                    "id": 34,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Chunk Samples",
+                            "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "First Compaction, Avg Chunk Samples",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "Head chunk is converted to chunk when it is filled with 120 samples. This graph shows the total number of head chunks created",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "ops"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 0,
+                        "y": 97
+                    },
+                    "id": 25,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_tsdb_head_chunks_removed_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Removed",
+                            "metric": "prometheus_local_storage_chunk_ops_total",
+                            "refId": "B",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Head Chunks Removed",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "bytes"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 8,
+                        "y": 97
+                    },
+                    "id": 35,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_tsdb_compaction_chunk_size_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) or rate(prometheus_tsdb_compaction_chunk_size_bytes_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Bytes/Sample",
+                            "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "First Compaction, Avg Bytes/Sample",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "This graph the difference of highest and lowest of TSDB watermark and also shows the size of isolation linked-chain",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 0,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 16,
+                        "y": 97
+                    },
+                    "id": 68,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "prometheus_tsdb_isolation_high_watermark{namespace='prombench-${prNumber}'} - prometheus_tsdb_isolation_low_watermark{namespace='prombench-${prNumber}'}",
+                            "legendFormat": "{{prometheus}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "TSDB Isolation Watermarks Difference",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "This graph shows chunks created per second",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "ops"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 0,
+                        "y": 104
+                    },
+                    "id": 4,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_tsdb_head_chunks_created_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Created",
+                            "metric": "prometheus_local_storage_chunk_ops_total",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "Head Chunks Created",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "description": "The latency distributions of fsync called by wal. High fsync duration (fsync_durations_seconds) indicates disk issues and might cause the cluster to be unstable",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 8,
+                        "x": 8,
+                        "y": 104
+                    },
+                    "id": 31,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "maxHeight": 600,
+                            "mode": "multi",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "P86B77AEF8F12A5FA"
+                            },
+                            "expr": "rate(prometheus_tsdb_wal_fsync_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_wal_fsync_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{prometheus}} - Fsync Latency",
+                            "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "title": "WAL Fsync Latency",
+                    "type": "timeseries"
+                }
+            ],
+            "title": "Attic: Old panels, likely to remove",
+            "type": "row"
+        }
+    ],
+    "refresh": "",
+    "schemaVersion": 39,
+    "style": "dark",
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "selected": false,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": true,
+                "multi": false,
+                "name": "RuleGroup",
+                "options": [],
+                "query": "prometheus_rule_group_last_duration_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                "refresh": 2,
+                "regex": ".*rule_group=\"(.*?)\".*",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "current": {
+                    "selected": true,
+                    "text": "18013",
+                    "value": "18013"
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "definition": "label_values(namespace)",
+                "description": "PR number",
+                "hide": 0,
+                "includeAll": false,
+                "multi": false,
+                "name": "prNumber",
+                "options": [],
+                "query": {
+                    "query": "label_values(namespace)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 1,
+                "regex": "prombench-(\\d+)",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-3h",
+        "to": "now"
+    },
+    "timeRangeUpdatedDuringEditOrView": false,
+    "timepicker": {
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "Prombench",
+    "uid": "7gmLoNDmz",
+    "version": 4
 }

--- a/prombench/manifests/cluster-infra/grafana_dashboard_dashboards_noparse.yaml
+++ b/prombench/manifests/cluster-infra/grafana_dashboard_dashboards_noparse.yaml
@@ -1488,4094 +1488,6052 @@ data:
     }
   prombench.json: |
     {
-      "__requires": [
-        {
-          "type": "grafana",
-          "id": "grafana",
-          "name": "Grafana",
-          "version": "5.0.0"
-        },
-        {
-          "type": "datasource",
-          "id": "prometheus",
-          "name": "Prometheus",
-          "version": "5.0.0"
-        }
-      ],
-      "annotations": {
-        "list": [
-          {
-            "builtIn": 1,
-            "datasource": "-- Grafana --",
-            "enable": true,
-            "hide": true,
-            "iconColor": "rgba(0, 211, 255, 1)",
-            "name": "Annotations & Alerts",
-            "type": "dashboard"
-          }
-        ]
-      },
-      "description": "Metrics useful for benchmarking and loadtesting Prometheus itself. Designed primarily for Prometheus 2.3.x.",
-      "tags": [
-        "benchmark",
-        "node-metrics"
-      ],
-      "editable": true,
-      "gnetId": 6725,
-      "graphTooltip": 1,
-      "id": null,
-      "iteration": 1532083926170,
-      "links": [],
-      "panels": [
-      {
-          "collapsed": true,
-          "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 0
-          },
-          "id": 47,
-          "panels": [
-          {
-              "aliasColors": {},
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "prometheus-meta",
-              "fill": 1,
-              "gridPos": {
-              "h": 9,
-              "w": 12,
-              "x": 0,
-              "y": 1
-              },
-              "id": 51,
-              "legend": {
-              "alignAsTable": true,
-              "avg": true,
-              "current": true,
-              "max": true,
-              "min": true,
-              "show": true,
-              "total": false,
-              "values": true
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [],
-              "nullPointMode": "null",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "spaceLength": 10,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-              {
-                  "expr": "node_memory_MemTotal_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-                  "format": "time_series",
-                  "hide": false,
-                  "intervalFactor": 1,
-                  "legendFormat": "{{node}} - Total memory",
-                  "refId": "E"
-              },
-              {
-                  "expr": "node_memory_MemTotal_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"} - node_memory_MemFree_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"} - node_memory_Buffers_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"} - node_memory_Cached_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-                  "format": "time_series",
-                  "intervalFactor": 1,
-                  "legendFormat": "{{node}} - Used",
-                  "refId": "A"
-              },
-              {
-                  "expr": "node_memory_Buffers_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-                  "format": "time_series",
-                  "intervalFactor": 1,
-                  "legendFormat": "{{node}} - Buffers",
-                  "refId": "B"
-              },
-              {
-                  "expr": "node_memory_Cached_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-                  "format": "time_series",
-                  "intervalFactor": 1,
-                  "legendFormat": "{{node}} - Cached",
-                  "refId": "C"
-              },
-              {
-                  "expr": "node_memory_MemFree_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-                  "format": "time_series",
-                  "intervalFactor": 1,
-                  "legendFormat": "{{node}} - Free",
-                  "refId": "D"
-              }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Memory",
-              "tooltip": {
-              "shared": true,
-              "sort": 0,
-              "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
-              },
-              "yaxes": [
-              {
-                  "format": "bytes",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-              },
-              {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-              }
-              ]
-          },
-          {
-              "aliasColors": {},
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "prometheus-meta",
-              "fill": 1,
-              "gridPos": {
-              "h": 9,
-              "w": 12,
-              "x": 12,
-              "y": 1
-              },
-              "id": 53,
-              "legend": {
-              "avg": false,
-              "current": false,
-              "max": false,
-              "min": false,
-              "show": true,
-              "total": false,
-              "values": false
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [],
-              "nullPointMode": "null",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "spaceLength": 10,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-              {
-                  "expr": "irate(node_disk_io_time_seconds_total{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\",device!~'^(md\\\\\\\\d+$|dm-)'}[5m])",
-                  "format": "time_series",
-                  "intervalFactor": 1,
-                  "legendFormat": "{{node}} - {{device}}",
-                  "refId": "A"
-              }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Disk I/O Utilisation",
-              "tooltip": {
-              "shared": true,
-              "sort": 0,
-              "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
-              },
-              "yaxes": [
-              {
-                  "format": "percentunit",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-              },
-              {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-              }
-              ]
-          },
-          {
-              "aliasColors": {},
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "prometheus-meta",
-              "fill": 1,
-              "gridPos": {
-              "h": 9,
-              "w": 12,
-              "x": 0,
-              "y": 10
-              },
-              "id": 57,
-              "legend": {
-              "avg": false,
-              "current": false,
-              "max": false,
-              "min": false,
-              "show": true,
-              "total": false,
-              "values": false
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [],
-              "nullPointMode": "null",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "spaceLength": 10,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-              {
-                  "expr": "irate(node_context_switches_total{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}[5m])",
-                  "format": "time_series",
-                  "intervalFactor": 1,
-                  "legendFormat": "{{node}} - Context Switches",
-                  "refId": "A"
-              },
-              {
-                  "expr": "irate(node_intr_total{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}[5m])",
-                  "format": "time_series",
-                  "intervalFactor": 1,
-                  "legendFormat": "{{node}} - Interrupts",
-                  "refId": "B"
-              }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Context Switches / Interrupts",
-              "tooltip": {
-              "shared": true,
-              "sort": 0,
-              "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
-              },
-              "yaxes": [
-              {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-              },
-              {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-              }
-              ]
-          },
-          {
-              "aliasColors": {},
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "prometheus-meta",
-              "description": "Disk space used of all filesystems mounted",
-              "fill": 1,
-              "gridPos": {
-              "h": 9,
-              "w": 12,
-              "x": 12,
-              "y": 10
-              },
-              "id": 61,
-              "legend": {
-              "alignAsTable": true,
-              "avg": true,
-              "current": true,
-              "max": true,
-              "min": true,
-              "show": true,
-              "total": false,
-              "values": true
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [],
-              "nullPointMode": "null",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "spaceLength": 10,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-              {
-                  "expr": "100 - ((node_filesystem_avail_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\",device!~'rootfs'} * 100) / node_filesystem_size_bytes{node=~'(test+).*',device!~'rootfs'})",
-                  "format": "time_series",
-                  "intervalFactor": 1,
-                  "legendFormat": "{{node}} - {{mountpoint}}",
-                  "refId": "A"
-              }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Disk Space Used Basic",
-              "tooltip": {
-              "shared": true,
-              "sort": 0,
-              "value_type": "individual"
-              },
-              "transparent": false,
-              "type": "graph",
-              "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
-              },
-              "yaxes": [
-              {
-                  "format": "percent",
-                  "label": null,
-                  "logBase": 1,
-                  "max": "100",
-                  "min": "0",
-                  "show": true
-              },
-              {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-              }
-              ]
-          },
-          {
-              "aliasColors": {},
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "prometheus-meta",
-              "fill": 1,
-              "gridPos": {
-              "h": 9,
-              "w": 12,
-              "x": 0,
-              "y": 19
-              },
-              "id": 59,
-              "legend": {
-              "alignAsTable": true,
-              "avg": true,
-              "current": true,
-              "max": true,
-              "min": true,
-              "show": true,
-              "total": false,
-              "values": true
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [],
-              "nullPointMode": "null",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "spaceLength": 10,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-              {
-                  "expr": "node_load1{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-                  "format": "time_series",
-                  "intervalFactor": 1,
-                  "legendFormat": "{{node}} - Load 1m",
-                  "refId": "A"
-              },
-              {
-                  "expr": "node_load5{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-                  "format": "time_series",
-                  "intervalFactor": 1,
-                  "legendFormat": "{{node}} - Load 5m",
-                  "refId": "B"
-              },
-              {
-                  "expr": "node_load15{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-                  "format": "time_series",
-                  "intervalFactor": 1,
-                  "legendFormat": "{{node}} - Load 15m",
-                  "refId": "C"
-              }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "System Load",
-              "tooltip": {
-              "shared": true,
-              "sort": 0,
-              "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
-              },
-              "yaxes": [
-              {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-              },
-              {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-              }
-              ]
-          },
-          {
-              "aliasColors": {},
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "prometheus-meta",
-              "fill": 1,
-              "gridPos": {
-              "h": 9,
-              "w": 12,
-              "x": 12,
-              "y": 19
-              },
-              "id": 55,
-              "legend": {
-              "avg": false,
-              "current": false,
-              "max": false,
-              "min": false,
-              "show": true,
-              "total": false,
-              "values": false
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [],
-              "nullPointMode": "null",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "spaceLength": 10,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-              {
-                  "expr": "1 - node_filesystem_free_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\",fstype!='rootfs',mountpoint!~'/(run|var).*',mountpoint!=''} / node_filesystem_size_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
-                  "format": "time_series",
-                  "intervalFactor": 1,
-                  "legendFormat": "{{node}} - {{mountpoint}}",
-                  "refId": "A"
-              }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Filesystem Fullness",
-              "tooltip": {
-              "shared": true,
-              "sort": 0,
-              "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
-              },
-              "yaxes": [
-              {
-                  "format": "percentunit",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-              },
-              {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-              }
-              ]
-          }
-          ],
-          "title": "Node Metrics",
-          "type": "row"
-      },
-      {
-          "collapsed": false,
-          "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 1
-          },
-          "id": 45,
-          "panels": [],
-          "title": "Prometheus Benchmark",
-          "type": "row"
-      },
-      {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 0,
-          "y": 2
-          },
-          "id": 40,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "prometheus_build_info{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{prometheus}} - {{version}} - {{revision}}",
-              "refId": "A"
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Prometheus Version",
-          "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 8,
-          "y": 2
-          },
-          "id": 42,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "time() - process_start_time_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{prometheus}} - Uptime",
-              "refId": "A"
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Uptime",
-          "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "dtdurations",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Max": "#e24d42",
-          "Open": "#508642"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "Total number open and maximum file descriptors of both release and PR",
-          "fill": 0,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 16,
-          "y": 2
-          },
-          "id": 41,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "process_max_fds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{prometheus}} - Max",
-              "refId": "A"
-          },
-          {
-              "expr": "process_open_fds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{prometheus}} - Open",
-              "refId": "B"
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "File Descriptors",
-          "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833",
-          "Time series": "#70dbed"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "This graph indicates how many time series each instance holds",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 0,
-          "y": 9
-          },
-          "id": 3,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "prometheus_tsdb_head_series{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Time series",
-              "metric": "prometheus_local_storage_memory_series",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Head Time series",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "This graph shows the total number of active appender transactions",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 8,
-          "y": 9
-          },
-          "id": 26,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "prometheus_tsdb_head_active_appenders{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Head Appenders",
-              "metric": "prometheus_local_storage_memory_series",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Head Active Appenders",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "samples/s": "#e5a8e2"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "This graph shows the sample ingested per second",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 16,
-          "y": 9
-          },
-          "id": 1,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - samples/s",
-              "metric": "prometheus_local_storage_ingested_samples_total",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Samples Appended/s",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "short",
-              "label": "",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833",
-          "To persist": "#9AC48A"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "Chunks are the collection of series of samples. The active series is known as the head chunk. Total of 120 samples are present in a chunk. This graph shows the total head chunks",
-          "editable": true,
-          "error": false,
-          "fill": 0,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 0,
-          "y": 16
-          },
-          "id": 2,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-          {
-              "alias": "/Max.*/",
-              "fill": 0
-          }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "prometheus_tsdb_head_chunks{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Chunks",
-              "metric": "prometheus_local_storage_memory_chunks",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Head Chunks",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "This graph shows chunks created per second",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 8,
-          "y": 16
-          },
-          "id": 4,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_tsdb_head_chunks_created_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Created",
-              "metric": "prometheus_local_storage_chunk_ops_total",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Head Chunks Created",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "ops",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833",
-          "Removed": "#e5ac0e"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "Head chunk is converted to chunk when it is filled with 120 samples. This graph shows the total number of head chunks created",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 16,
-          "y": 16
-          },
-          "id": 25,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_tsdb_head_chunks_removed_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Removed",
-              "metric": "prometheus_local_storage_chunk_ops_total",
-              "refId": "B",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Head Chunks Removed",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "ops",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max": "#447ebc",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833",
-          "Min": "#447ebc",
-          "Now": "#7eb26d"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "Plots of minimum and maximum timestamp of the head block in reference to current time",
-          "editable": true,
-          "error": false,
-          "fill": 0,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 0,
-          "y": 23
-          },
-          "id": 28,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-          {
-              "alias": "Max",
-              "fillBelowTo": "Min",
-              "lines": false
-          }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "prometheus_tsdb_head_min_time{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Min",
-              "metric": "prometheus_local_storage_series_chunks_persisted_count",
-              "refId": "A",
-              "step": 10
-          },
-          {
-              "expr": "time() * 1000",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "Now",
-              "refId": "C"
-          },
-          {
-              "expr": "prometheus_tsdb_head_max_time{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Max",
-              "metric": "prometheus_local_storage_series_chunks_persisted_count",
-              "refId": "B",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Head Time Range",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "decimals": null,
-              "format": "dateTimeAsIso",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "Average runtime of garbage collection in the head block",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 8,
-          "y": 23
-          },
-          "id": 29,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_tsdb_head_gc_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_head_gc_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - GC Time/s",
-              "metric": "prometheus_local_storage_series_chunks_persisted_count",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Avg Head GC Time/s",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "Total Number of currently loaded data blocks",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 16,
-          "y": 23
-          },
-          "id": 14,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-          {
-              "alias": "Queue length",
-              "yaxis": 2
-          }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "prometheus_tsdb_blocks_loaded{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Blocks Loaded",
-              "metric": "prometheus_local_storage_indexing_batch_sizes_sum",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Blocks Loaded",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Allocated bytes": "#F9BA8F",
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833",
-          "RSS": "#890F02"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "Total number of bytes allocated, even if freed",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 0,
-          "y": 30
-          },
-          "id": 7,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Allocated Bytes/s",
-              "metric": "go_memstats_alloc_bytes",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Allocations",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "bytes",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Failed Compactions": "#bf1b00",
-          "Failed Reloads": "#bf1b00",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "This graph shows the total number of times the database reloaded block data from disk",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 8,
-          "y": 30
-          },
-          "id": 30,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_tsdb_reloads_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Reloads",
-              "metric": "prometheus_local_storage_series_chunks_persisted_count",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "TSDB Reloads/s",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "none",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Failed Compactions": "#bf1b00",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833",
-          "{instance=\"demo.robustperception.io:9090\",job=\"prometheus\"}": "#bf1b00"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "This graph shows various tsdb related checks",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 16,
-          "y": 30
-          },
-          "id": 32,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_tsdb_wal_corruptions_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - WAL Corruptions",
-              "metric": "prometheus_local_storage_series_chunks_persisted_count",
-              "refId": "A",
-              "step": 10
-          },
-          {
-              "expr": "rate(prometheus_tsdb_reloads_failures_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Reload Failures",
-              "metric": "prometheus_local_storage_series_chunks_persisted_count",
-              "refId": "B",
-              "step": 10
-          },
-          {
-              "expr": "rate(prometheus_tsdb_head_series_not_found{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Head Series Not Found",
-              "metric": "prometheus_local_storage_series_chunks_persisted_count",
-              "refId": "C",
-              "step": 10
-          },
-          {
-              "expr": "rate(prometheus_tsdb_compactions_failed_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Compaction Failures",
-              "metric": "prometheus_local_storage_series_chunks_persisted_count",
-              "refId": "D",
-              "step": 10
-          },
-          {
-              "expr": "rate(prometheus_tsdb_retention_cutoffs_failures_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Retention Cutoff Failures",
-              "metric": "prometheus_local_storage_series_chunks_persisted_count",
-              "refId": "E",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "TSDB Problems/s",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "none",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Allocated bytes": "#F9BA8F",
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833",
-          "RSS": "#890F02"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "Total number of times the database cut off block data from disk",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 0,
-          "y": 37
-          },
-          "id": 8,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_tsdb_retention_cutoffs_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Retention Cutoffs",
-              "metric": "last",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Retention Cutoffs/s",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "none",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Failed Compactions": "#bf1b00",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "The latency distributions of fsync called by wal. High fsync duration (fsync_durations_seconds) indicates disk issues and might cause the cluster to be unstable",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 8,
-          "y": 37
-          },
-          "id": 31,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_tsdb_wal_fsync_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_wal_fsync_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Fsync Latency",
-              "metric": "prometheus_local_storage_series_chunks_persisted_count",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "WAL Fsync Latency",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Failed Compactions": "#bf1b00",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "WAL is used to get the backup when the prometheus server crashes. WAL stores the last 2hrs of data in memory. After that it has to truncate the data. So, this graph shows the latency of truncation",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 16,
-          "y": 37
-          },
-          "id": 65,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_tsdb_wal_truncate_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_wal_truncate_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Truncate Latency",
-              "metric": "prometheus_local_storage_series_chunks_persisted_count",
-              "refId": "B",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "WAL Truncate Latency",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 0,
-          "y": 44
-          },
-          "id": 35,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_tsdb_compaction_chunk_size_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) or rate(prometheus_tsdb_compaction_chunk_size_bytes_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Bytes/Sample",
-              "metric": "prometheus_local_storage_series_chunks_persisted_count",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "First Compaction, Avg Bytes/Sample",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "decimals": null,
-              "format": "bytes",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 8,
-          "y": 44
-          },
-          "id": 27,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_tsdb_compaction_chunk_range_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_range_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) or rate(prometheus_tsdb_compaction_chunk_range_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_range_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Chunk Time Range",
-              "metric": "prometheus_local_storage_series_chunks_persisted_count",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "First Compaction, Avg Chunk Time Range",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "decimals": null,
-              "format": "ms",
-              "label": "",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 16,
-          "y": 44
-          },
-          "id": 34,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Chunk Samples",
-              "metric": "prometheus_local_storage_series_chunks_persisted_count",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "First Compaction, Avg Chunk Samples",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "none",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Failed Compactions": "#bf1b00",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "Total number of compactions that were executed for the partition",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 0,
-          "y": 51
-          },
-          "id": 19,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_tsdb_compactions_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Compactions",
-              "metric": "prometheus_local_storage_series_chunks_persisted_count",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Compactions/s",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "none",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "Average compactions that were executed for the partition",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 8,
-          "y": 51
-          },
-          "id": 33,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_tsdb_compaction_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}}",
-              "metric": "prometheus_local_storage_series_chunks_persisted_count",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Avg Compaction Time/s",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "decimals": 2,
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 16,
-          "y": 51
-          },
-          "id": 9,
-          "legend": {
-          "alignAsTable": false,
-          "avg": false,
-          "current": false,
-          "hideEmpty": false,
-          "max": false,
-          "min": false,
-          "rightSide": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "irate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Irate",
-              "metric": "prometheus_local_storage_ingested_samples_total",
-              "refId": "A",
-              "step": 10
-          },
-          {
-              "expr": "rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[5m])",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - 5m rate",
-              "metric": "prometheus_local_storage_ingested_samples_total",
-              "refId": "B",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "CPU",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": [
-              "avg"
-          ]
-          },
-          "yaxes": [
-          {
-              "format": "none",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Allocated bytes": "#7EB26D",
-          "Allocated bytes - 1m max": "#BF1B00",
-          "Allocated bytes - 1m min": "#BF1B00",
-          "Allocated bytes - 5m max": "#BF1B00",
-          "Allocated bytes - 5m min": "#BF1B00",
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833",
-          "RSS": "#447EBC"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "decimals": null,
-          "editable": true,
-          "error": false,
-          "fill": 0,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 0,
-          "y": 58
-          },
-          "id": 6,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-          {
-              "alias": "/-/",
-              "fill": 0
-          }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - RSS",
-              "metric": "process_resident_memory_bytes",
-              "refId": "B",
-              "step": 10
-          },
-          {
-              "expr": "prometheus_local_storage_target_heap_size_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Target heap size",
-              "metric": "go_memstats_alloc_bytes",
-              "refId": "D",
-              "step": 10
-          },
-          {
-              "expr": "go_memstats_next_gc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Next GC",
-              "metric": "go_memstats_next_gc_bytes",
-              "refId": "C",
-              "step": 10
-          },
-          {
-              "expr": "go_memstats_alloc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Allocated",
-              "metric": "go_memstats_alloc_bytes",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Memory",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "bytes",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "",
-          "editable": true,
-          "error": false,
-          "fill": 0,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 8,
-          "y": 58
-          },
-          "id": 38,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - {{handler}}",
-              "metric": "prometheus_local_storage_memory_chunkdescs",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "HTTP requests/s",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "reqps",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "",
-          "editable": true,
-          "error": false,
-          "fill": 0,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 16,
-          "y": 58
-          },
-          "id": 37,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - {{handler}}",
-              "metric": "prometheus_local_storage_memory_chunkdescs",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Avg HTTP request latency",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "Time spent in prepare_time mode, per second",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 0,
-          "y": 65
-          },
-          "id": 64,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"prepare_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"prepare_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}}",
-              "metric": "prometheus_local_storage_memory_chunkdescs",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Avg query engine timings/s - prepare_time",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "Average Time spent in inner_eval mode, per second",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 8,
-          "y": 65
-          },
-          "id": 24,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"inner_eval\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"inner_eval\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}}",
-              "metric": "prometheus_local_storage_memory_chunkdescs",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Avg query engine timings/s - inner_eval",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "Time spent in queue_time mode, per second",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 16,
-          "y": 65
-          },
-          "id": 63,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"queue_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"queue_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}}",
-              "metric": "prometheus_local_storage_memory_chunkdescs",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Avg query engine timings/s - queue_time",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "Average Time spent in result_sort mode, per second",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 0,
-          "y": 72
-          },
-          "id": 62,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"result_sort\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"result_sort\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}}",
-              "metric": "prometheus_local_storage_memory_chunkdescs",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Avg query engine timings/s - result_sort",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 8,
-          "y": 72
-          },
-          "id": 22,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_rule_group_iterations_missed_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])  ",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Rule group missed",
-              "metric": "prometheus_local_storage_memory_chunkdescs",
-              "refId": "B",
-              "step": 10
-          },
-          {
-              "expr": "rate(prometheus_rule_evaluation_failures_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Rule evals failed",
-              "metric": "prometheus_local_storage_memory_chunkdescs",
-              "refId": "C",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Rule group evaluation problems/s",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 16,
-          "y": 72
-          },
-          "id": 23,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "rate(prometheus_rule_group_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Rule evaluation duration",
-              "metric": "prometheus_local_storage_memory_chunkdescs",
-              "refId": "A",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Evaluation time of rule groups/s",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-          "aliasColors": {
-          "Chunks": "#1F78C1",
-          "Chunks to persist": "#508642",
-          "Interval": "#890f02",
-          "Last Duration": "#f9934e",
-          "Max chunks": "#052B51",
-          "Max to persist": "#3F6833"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus-meta",
-          "description": "Rule group describe the Prometheus alerts. These graph consist of two rules:\n- prometheus_rule_group_interval_seconds:  When the first notification was sent, wait for 'group_interval' to send a batch of new alerts that started firing for that group.\n- prometheus_rule_group_last_duration_seconds: It shows the last duration of each one of your groups in seconds\n",
-          "editable": true,
-          "error": false,
-          "fill": 0,
-          "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 0,
-          "y": 79
-          },
-          "id": 43,
-          "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "repeat": "RuleGroup",
-          "repeatDirection": "h",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-          {
-              "expr": "prometheus_rule_group_interval_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",rule_group=~\"$RuleGroup\"}\n",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Interval",
-              "metric": "prometheus_local_storage_memory_chunkdescs",
-              "refId": "A",
-              "step": 10
-          },
-          {
-              "expr": "prometheus_rule_group_last_duration_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",rule_group=~\"$RuleGroup\"}\n",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{prometheus}} - Last Duration",
-              "metric": "prometheus_local_storage_memory_chunkdescs",
-              "refId": "B",
-              "step": 10
-          }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Rule Group: $RuleGroup",
-          "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-          },
-          "yaxes": [
-          {
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-          },
-          {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-          }
-          ]
-      },
-      {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "description": "This graph shows the highest and lowest TSDB watermarks. The highest watermark represents the latest appender and the lowest watermark represents the oldest appender",
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 79
-      },
-      "id": 67,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "prometheus_tsdb_isolation_low_watermark{namespace='prombench-${prNumber}'}",
-          "legendFormat": "{{prometheus}} - low watermark",
-          "refId": "A"
-        },
-        {
-          "expr": "prometheus_tsdb_isolation_high_watermark{namespace='prombench-${prNumber}'}",
-          "interval": "",
-          "legendFormat": "{{prometheus}} - high watermark",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "TSDB Isolation Watermarks",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "description": "This graph the difference of highest and lowest of TSDB watermark and also shows the size of isolation linked-chain",
-        "fill": 0,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 16,
-          "y": 79
-        },
-        "id": 68,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 1,
-        "nullPointMode": "null",
-        "options": {
-          "dataLinks": []
-        },
-        "percentage": false,
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "expr": "prometheus_tsdb_isolation_high_watermark{namespace='prombench-${prNumber}'} - prometheus_tsdb_isolation_low_watermark{namespace='prombench-${prNumber}'}",
-            "legendFormat": "{{prometheus}}",
-            "refId": "A"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "TSDB Isolation Watermarks Difference",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          },
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
-      }
-      ],
-      "refresh": false,
-      "schemaVersion": 16,
-      "style": "dark",
-      "templating": {
-        "list": [
-          {
-            "allValue": null,
-            "current": {},
-            "datasource": "prometheus-meta",
-            "hide": 2,
-            "includeAll": true,
-            "label": null,
-            "multi": false,
-            "name": "RuleGroup",
-            "options": [],
-            "query": "prometheus_rule_group_last_duration_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
-            "refresh": 2,
-            "regex": ".*rule_group=\"(.*?)\".*",
-            "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          },
-          {
-            "allValue": null,
-            "current": {},
-            "datasource": "prometheus-meta",
-            "definition": "label_values(namespace)",
-            "description": "PR number",
-            "hide": 0,
-            "includeAll": false,
-            "multi": false,
-            "name": "prNumber",
-            "options": [],
-            "query": {
-              "query": "label_values(namespace)",
-              "refId": "StandardVariableQuery"
+        "__requires": [
+            {
+                "type": "grafana",
+                "id": "grafana",
+                "name": "Grafana",
+                "version": "5.0.0"
             },
-            "refresh": 1,
-            "regex": "prombench-(\\d+)",
-            "skipUrlSync": false,
-            "sort": 0,
-            "type": "query"
-          }
-        ]
-      },
-      "time": {
-        "from": "now-30m",
-        "to": "now"
-      },
-      "timepicker": {
-        "refresh_intervals": [
-          "5s",
-          "10s",
-          "30s",
-          "1m",
-          "5m",
-          "15m",
-          "30m",
-          "1h",
-          "2h",
-          "1d"
+            {
+                "type": "datasource",
+                "id": "prometheus",
+                "name": "Prometheus",
+                "version": "5.0.0"
+            }
         ],
-        "time_options": [
-          "5m",
-          "15m",
-          "1h",
-          "6h",
-          "12h",
-          "24h",
-          "2d",
-          "7d",
-          "30d"
-        ]
-      },
-      "timezone": "browser",
-      "title": "Prombench",
-      "uid": "7gmLoNDmz",
-      "version": 3
+        "annotations": {
+            "list": [
+                {
+                    "builtIn": 1,
+                    "datasource": "-- Grafana --",
+                    "enable": true,
+                    "hide": true,
+                    "iconColor": "rgba(0, 211, 255, 1)",
+                    "name": "Annotations & Alerts",
+                    "type": "dashboard"
+                }
+            ]
+        },
+        "description": "Metrics useful for benchmarking and loadtesting Prometheus itself. Designed primarily for Prometheus 3.x.",
+        "tags": [
+            "benchmark",
+            "node-metrics"
+        ],
+        "editable": true,
+        "gnetId": 6725,
+        "graphTooltip": 1,
+        "id": null,
+        "links": [],
+        "panels": [
+            {
+                "collapsed": false,
+                "gridPos": {
+                    "h": 1,
+                    "w": 24,
+                    "x": 0,
+                    "y": 0
+                },
+                "id": 69,
+                "panels": [],
+                "title": "Acceptance: 💾 Memory",
+                "type": "row"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "description": "Delta of number of bytes allocated per second (go_memstats_alloc_bytes_total), even if freed. PR minus Reference, so negative values indicate how much less PR allocates.\n\n10m lower than our periodic scrape load scale ups and downs cycles (~30m interval) but large enough to hide noise.",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "palette-classic"
+                        },
+                        "custom": {
+                            "axisBorderShow": false,
+                            "axisCenteredZero": false,
+                            "axisColorMode": "text",
+                            "axisLabel": "",
+                            "axisPlacement": "auto",
+                            "barAlignment": 0,
+                            "drawStyle": "line",
+                            "fillOpacity": 10,
+                            "gradientMode": "none",
+                            "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                            },
+                            "insertNulls": false,
+                            "lineInterpolation": "linear",
+                            "lineWidth": 1,
+                            "pointSize": 5,
+                            "scaleDistribution": {
+                                "type": "linear"
+                            },
+                            "showPoints": "never",
+                            "spanNulls": false,
+                            "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                            },
+                            "thresholdsStyle": {
+                                "mode": "dashed"
+                            }
+                        },
+                        "mappings": [],
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        "unit": "bytes"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 9,
+                    "w": 16,
+                    "x": 0,
+                    "y": 1
+                },
+                "id": 70,
+                "options": {
+                    "legend": {
+                        "calcs": [
+                            "mean",
+                            "max"
+                        ],
+                        "displayMode": "table",
+                        "placement": "bottom",
+                        "showLegend": true,
+                        "sortBy": "Name",
+                        "sortDesc": true
+                    },
+                    "tooltip": {
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                    }
+                },
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "sum(rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\"}[10m])) - sum(rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\"}[10m]))",
+                        "hide": false,
+                        "intervalFactor": 2,
+                        "legendFormat": "PR vs Ref - Allocated Bytes/s ",
+                        "metric": "go_memstats_alloc_bytes",
+                        "range": true,
+                        "refId": "A",
+                        "step": 10
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\"}[10m])",
+                        "hide": false,
+                        "intervalFactor": 2,
+                        "legendFormat": "{{prometheus}} - Allocated Bytes/s ",
+                        "metric": "go_memstats_alloc_bytes",
+                        "range": true,
+                        "refId": "B",
+                        "step": 10
+                    }
+                ],
+                "title": "rate[10m] Go Heap Allocations (PR vs Ref: smaller, ideally negative, is better)",
+                "type": "timeseries"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "description": "Ref % of Delta of number of bytes allocated per second (go_memstats_alloc_bytes_total), even if freed. PR minus Reference, so negative values indicate how much less PR allocates.\n",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [],
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 9,
+                    "w": 8,
+                    "x": 16,
+                    "y": 1
+                },
+                "id": 75,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "mean"
+                        ],
+                        "fields": "/^PR vs Ref \\- Allocated Bytes/s $/",
+                        "values": false
+                    },
+                    "showPercentChange": false,
+                    "textMode": "value_and_name",
+                    "wideLayout": true
+                },
+                "pluginVersion": "11.0.0",
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "(sum(rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\"}[10m])) - sum(rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\"}[10m]))) / sum(rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\"}[10m]))",
+                        "hide": false,
+                        "intervalFactor": 2,
+                        "legendFormat": "PR vs Ref - Allocated Bytes/s ",
+                        "metric": "go_memstats_alloc_bytes",
+                        "range": true,
+                        "refId": "A",
+                        "step": 10
+                    }
+                ],
+                "type": "stat"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "description": "Delta of number of avg bytes allocated within 30m windows for RSS and heap.\n\nPR minus Reference, so negative values indicate how much less PR allocates.\n",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "palette-classic"
+                        },
+                        "custom": {
+                            "axisBorderShow": false,
+                            "axisCenteredZero": false,
+                            "axisColorMode": "text",
+                            "axisLabel": "",
+                            "axisPlacement": "auto",
+                            "barAlignment": 0,
+                            "drawStyle": "line",
+                            "fillOpacity": 10,
+                            "gradientMode": "none",
+                            "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                            },
+                            "insertNulls": false,
+                            "lineInterpolation": "linear",
+                            "lineStyle": {
+                                "fill": "solid"
+                            },
+                            "lineWidth": 1,
+                            "pointSize": 5,
+                            "scaleDistribution": {
+                                "type": "linear"
+                            },
+                            "showPoints": "never",
+                            "spanNulls": false,
+                            "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                            },
+                            "thresholdsStyle": {
+                                "mode": "dashed"
+                            }
+                        },
+                        "mappings": [],
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        "unit": "bytes"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 10,
+                    "w": 16,
+                    "x": 0,
+                    "y": 10
+                },
+                "id": 71,
+                "options": {
+                    "legend": {
+                        "calcs": [
+                            "mean",
+                            "max"
+                        ],
+                        "displayMode": "table",
+                        "placement": "bottom",
+                        "showLegend": true
+                    },
+                    "tooltip": {
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                    }
+                },
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "sum(avg_over_time(go_memstats_alloc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\"}[10m])) - sum(avg_over_time(go_memstats_alloc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\", prometheus!~\"test-pr.*\"}[10m]))",
+                        "intervalFactor": 2,
+                        "legendFormat": "PR vs Ref - Allocated (heap)",
+                        "metric": "go_memstats_alloc_bytes",
+                        "range": true,
+                        "refId": "A",
+                        "step": 10
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "sum(avg_over_time(process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\"}[10m])) - sum(avg_over_time(process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\", prometheus!~\"test-pr.*\"}[10m]))",
+                        "hide": false,
+                        "intervalFactor": 2,
+                        "legendFormat": "PR vs Ref - RSS",
+                        "metric": "process_resident_memory_bytes",
+                        "range": true,
+                        "refId": "C",
+                        "step": 10
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "avg_over_time(process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\"}[10m])",
+                        "hide": false,
+                        "intervalFactor": 2,
+                        "legendFormat": "{{prometheus}}- RSS",
+                        "metric": "process_resident_memory_bytes",
+                        "range": true,
+                        "refId": "B",
+                        "step": 10
+                    }
+                ],
+                "title": "avg[10m] Allocations (PR vs Ref: smaller, ideally negative, is better)",
+                "type": "timeseries"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "description": "Ref % of Delta of number of avg bytes allocated within 30m windows for RSS and heap.\n\nPR minus Reference, so negative values indicate how much less PR allocates.\n",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [],
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 10,
+                    "w": 8,
+                    "x": 16,
+                    "y": 10
+                },
+                "id": 76,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "mean"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "showPercentChange": false,
+                    "textMode": "value_and_name",
+                    "wideLayout": true
+                },
+                "pluginVersion": "11.0.0",
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "(sum(avg_over_time(go_memstats_alloc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\"}[10m])) - sum(avg_over_time(go_memstats_alloc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\", prometheus!~\"test-pr.*\"}[10m])))/  sum(avg_over_time(go_memstats_alloc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\", prometheus!~\"test-pr.*\"}[10m]))",
+                        "intervalFactor": 2,
+                        "legendFormat": "PR vs Ref - Allocated (heap)",
+                        "metric": "go_memstats_alloc_bytes",
+                        "range": true,
+                        "refId": "A",
+                        "step": 10
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "(sum(avg_over_time(process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\"}[10m])) - sum(avg_over_time(process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\", prometheus!~\"test-pr.*\"}[10m]))) / sum(avg_over_time(process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\", prometheus!~\"test-pr.*\"}[10m]))",
+                        "hide": false,
+                        "intervalFactor": 2,
+                        "legendFormat": "PR vs Ref - RSS",
+                        "metric": "process_resident_memory_bytes",
+                        "range": true,
+                        "refId": "C",
+                        "step": 10
+                    }
+                ],
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "gridPos": {
+                    "h": 1,
+                    "w": 24,
+                    "x": 0,
+                    "y": 20
+                },
+                "id": 74,
+                "panels": [],
+                "title": "Acceptance: 💻 CPU ",
+                "type": "row"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "description": "Delta of per second process CPU usage.\n\nPR minus Reference, so negative values indicate how much less the PR use CPU.\n",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "palette-classic"
+                        },
+                        "custom": {
+                            "axisBorderShow": false,
+                            "axisCenteredZero": false,
+                            "axisColorMode": "text",
+                            "axisLabel": "",
+                            "axisPlacement": "auto",
+                            "barAlignment": 0,
+                            "drawStyle": "line",
+                            "fillOpacity": 10,
+                            "gradientMode": "none",
+                            "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                            },
+                            "insertNulls": false,
+                            "lineInterpolation": "linear",
+                            "lineWidth": 1,
+                            "pointSize": 5,
+                            "scaleDistribution": {
+                                "type": "linear"
+                            },
+                            "showPoints": "never",
+                            "spanNulls": false,
+                            "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                            },
+                            "thresholdsStyle": {
+                                "mode": "dashed"
+                            }
+                        },
+                        "mappings": [],
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        "unit": "none"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 8,
+                    "w": 16,
+                    "x": 0,
+                    "y": 21
+                },
+                "id": 72,
+                "options": {
+                    "legend": {
+                        "calcs": [
+                            "mean",
+                            "max"
+                        ],
+                        "displayMode": "table",
+                        "placement": "bottom",
+                        "showLegend": true
+                    },
+                    "tooltip": {
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                    }
+                },
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "sum(rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\"}[10m])) - sum(rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\"}[10m]))",
+                        "intervalFactor": 2,
+                        "legendFormat": "PR vs Ref - rate",
+                        "metric": "prometheus_local_storage_ingested_samples_total",
+                        "range": true,
+                        "refId": "B",
+                        "step": 10
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                        "hide": false,
+                        "intervalFactor": 2,
+                        "legendFormat": "{{prometheus}} - rate",
+                        "metric": "prometheus_local_storage_ingested_samples_total",
+                        "range": true,
+                        "refId": "A",
+                        "step": 10
+                    }
+                ],
+                "title": "rate[10m] CPU (PR vs Ref: smaller, ideally negative, is better)",
+                "type": "timeseries"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "description": "Ref % of Delta of per second process CPU usage.\n\nPR minus Reference, so negative values indicate how much less the PR use CPU.\n",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [],
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 8,
+                    "w": 8,
+                    "x": 16,
+                    "y": 21
+                },
+                "id": 77,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "mean"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "showPercentChange": false,
+                    "textMode": "value_and_name",
+                    "wideLayout": true
+                },
+                "pluginVersion": "11.0.0",
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "(sum(rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\"}[10m])) - sum(rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\"}[10m]))) / sum(rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\"}[10m]))",
+                        "intervalFactor": 2,
+                        "legendFormat": "PR vs Ref - rate",
+                        "metric": "prometheus_local_storage_ingested_samples_total",
+                        "range": true,
+                        "refId": "B",
+                        "step": 10
+                    }
+                ],
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "gridPos": {
+                    "h": 1,
+                    "w": 24,
+                    "x": 0,
+                    "y": 29
+                },
+                "id": 86,
+                "panels": [],
+                "title": "Acceptance: 🧭 Query Latency",
+                "type": "row"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "description": "",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "palette-classic"
+                        },
+                        "custom": {
+                            "axisBorderShow": false,
+                            "axisCenteredZero": false,
+                            "axisColorMode": "text",
+                            "axisLabel": "",
+                            "axisPlacement": "auto",
+                            "barAlignment": 0,
+                            "drawStyle": "line",
+                            "fillOpacity": 10,
+                            "gradientMode": "none",
+                            "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                            },
+                            "insertNulls": false,
+                            "lineInterpolation": "linear",
+                            "lineWidth": 1,
+                            "pointSize": 5,
+                            "scaleDistribution": {
+                                "type": "linear"
+                            },
+                            "showPoints": "never",
+                            "spanNulls": false,
+                            "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                            },
+                            "thresholdsStyle": {
+                                "mode": "dashed"
+                            }
+                        },
+                        "mappings": [],
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "semi-dark-red",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 9,
+                    "w": 16,
+                    "x": 0,
+                    "y": 30
+                },
+                "id": 85,
+                "options": {
+                    "legend": {
+                        "calcs": [
+                            "mean",
+                            "max"
+                        ],
+                        "displayMode": "table",
+                        "placement": "bottom",
+                        "showLegend": true
+                    },
+                    "tooltip": {
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                    }
+                },
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]))  - sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]))",
+                        "format": "time_series",
+                        "hide": false,
+                        "intervalFactor": 2,
+                        "legendFormat": "PR vs Ref - {{handler}}",
+                        "metric": "prometheus_local_storage_memory_chunkdescs",
+                        "range": true,
+                        "refId": "A",
+                        "step": 10
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",handler=\"/api/v1/query\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",handler=\"/api/v1/query\"}[10m])",
+                        "hide": false,
+                        "instant": false,
+                        "legendFormat": "{{prometheus}} - {{handler}}",
+                        "range": true,
+                        "refId": "B"
+                    }
+                ],
+                "title": "rate[10m] Query Instant Latency (PR vs Ref: smaller, ideally negative, is better)",
+                "type": "timeseries"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "description": "Ref % of Delta of Query instant latency\n\nPR minus Reference, so negative values indicate how much less the PR use CPU.\n",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [],
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 9,
+                    "w": 8,
+                    "x": 16,
+                    "y": 30
+                },
+                "id": 88,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "mean"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "showPercentChange": false,
+                    "textMode": "value_and_name",
+                    "wideLayout": true
+                },
+                "pluginVersion": "11.0.0",
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "(sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]))  - sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]))) / sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query\"}[10m]))",
+                        "intervalFactor": 2,
+                        "legendFormat": "PR vs Ref - {{handler}}",
+                        "metric": "prometheus_local_storage_ingested_samples_total",
+                        "range": true,
+                        "refId": "B",
+                        "step": 10
+                    }
+                ],
+                "type": "stat"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "description": "",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "palette-classic"
+                        },
+                        "custom": {
+                            "axisBorderShow": false,
+                            "axisCenteredZero": false,
+                            "axisColorMode": "text",
+                            "axisLabel": "",
+                            "axisPlacement": "auto",
+                            "barAlignment": 0,
+                            "drawStyle": "line",
+                            "fillOpacity": 10,
+                            "gradientMode": "none",
+                            "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                            },
+                            "insertNulls": false,
+                            "lineInterpolation": "linear",
+                            "lineWidth": 1,
+                            "pointSize": 5,
+                            "scaleDistribution": {
+                                "type": "linear"
+                            },
+                            "showPoints": "never",
+                            "spanNulls": false,
+                            "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                            },
+                            "thresholdsStyle": {
+                                "mode": "dashed"
+                            }
+                        },
+                        "mappings": [],
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "semi-dark-red",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 8,
+                    "w": 16,
+                    "x": 0,
+                    "y": 39
+                },
+                "id": 87,
+                "options": {
+                    "legend": {
+                        "calcs": [
+                            "mean",
+                            "max"
+                        ],
+                        "displayMode": "table",
+                        "placement": "bottom",
+                        "showLegend": true
+                    },
+                    "tooltip": {
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                    }
+                },
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]))  - sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]))",
+                        "format": "time_series",
+                        "hide": false,
+                        "intervalFactor": 2,
+                        "legendFormat": "PR vs Ref - {{handler}}",
+                        "metric": "prometheus_local_storage_memory_chunkdescs",
+                        "range": true,
+                        "refId": "A",
+                        "step": 10
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",handler=\"/api/v1/query_range\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",handler=\"/api/v1/query_range\"}[10m])",
+                        "hide": false,
+                        "instant": false,
+                        "legendFormat": "{{prometheus}} - {{handler}}",
+                        "range": true,
+                        "refId": "B"
+                    }
+                ],
+                "title": "rate[10m] Query Range Latency (PR vs Ref: smaller, ideally negative, is better)",
+                "type": "timeseries"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "description": "Ref % of Delta of Query range latency\n\nPR minus Reference, so negative values indicate how much less the PR use CPU.\n",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [],
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 8,
+                    "w": 8,
+                    "x": 16,
+                    "y": 39
+                },
+                "id": 89,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "mean"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "showPercentChange": false,
+                    "textMode": "value_and_name",
+                    "wideLayout": true
+                },
+                "pluginVersion": "11.0.0",
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "(sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]))  - sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]))) / sum by(handler) (rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\", prometheus!~\"test-pr.*\",handler=\"/api/v1/query_range\"}[10m]))",
+                        "intervalFactor": 2,
+                        "legendFormat": "PR vs Ref - {{handler}}",
+                        "metric": "prometheus_local_storage_ingested_samples_total",
+                        "range": true,
+                        "refId": "B",
+                        "step": 10
+                    }
+                ],
+                "type": "stat"
+            },
+            {
+                "collapsed": true,
+                "gridPos": {
+                    "h": 1,
+                    "w": 24,
+                    "x": 0,
+                    "y": 47
+                },
+                "id": 79,
+                "panels": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 0,
+                            "y": 30
+                        },
+                        "id": 40,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "prometheus_build_info{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{prometheus}} - {{version}} - {{revision}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "Prometheus Version",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "dtdurations"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 8,
+                            "y": 30
+                        },
+                        "id": 42,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "time() - process_start_time_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{prometheus}} - Uptime",
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "Uptime",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "This graph shows the sample ingested per second",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 16,
+                            "y": 30
+                        },
+                        "id": 1,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - samples/s",
+                                "metric": "prometheus_local_storage_ingested_samples_total",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Samples Appended/s",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "This graph indicates how many time series each instance holds",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 0,
+                            "y": 37
+                        },
+                        "id": 3,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "prometheus_tsdb_head_series{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Time series",
+                                "metric": "prometheus_local_storage_memory_series",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Head Time series",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "This graph shows the total number of times the database reloaded block data from disk",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "none"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 8,
+                            "y": 37
+                        },
+                        "id": 30,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_tsdb_reloads_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Reloads",
+                                "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "TSDB Reloads/s",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "Total Number of currently loaded data blocks",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 16,
+                            "y": 37
+                        },
+                        "id": 14,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "prometheus_tsdb_blocks_loaded{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Blocks Loaded",
+                                "metric": "prometheus_local_storage_indexing_batch_sizes_sum",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Blocks Loaded",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "This graph shows various tsdb related checks",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "none"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 0,
+                            "y": 44
+                        },
+                        "id": 32,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_tsdb_wal_corruptions_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - WAL Corruptions",
+                                "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                                "refId": "A",
+                                "step": 10
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_tsdb_reloads_failures_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Reload Failures",
+                                "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                                "refId": "B",
+                                "step": 10
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_tsdb_head_series_not_found{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Head Series Not Found",
+                                "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                                "refId": "C",
+                                "step": 10
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_tsdb_compactions_failed_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Compaction Failures",
+                                "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                                "refId": "D",
+                                "step": 10
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_tsdb_retention_cutoffs_failures_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Retention Cutoff Failures",
+                                "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                                "refId": "E",
+                                "step": 10
+                            }
+                        ],
+                        "title": "TSDB Problems/s",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "Total number of compactions that were executed for the partition",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "none"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 8,
+                            "y": 44
+                        },
+                        "id": 19,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_tsdb_compactions_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Compactions",
+                                "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Compactions/s",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "Step 61s is to avoid aliasing (max interval of our queries is 1m)",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 0,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        }
+                                    ]
+                                },
+                                "unit": "reqps"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 16,
+                            "y": 44
+                        },
+                        "id": 38,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "editorMode": "code",
+                                "expr": "rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                                "format": "time_series",
+                                "interval": "61s",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - {{handler}}",
+                                "metric": "prometheus_local_storage_memory_chunkdescs",
+                                "range": true,
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "HTTP requests/s",
+                        "type": "timeseries"
+                    }
+                ],
+                "title": "Functional Check",
+                "type": "row"
+            },
+            {
+                "collapsed": false,
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "gridPos": {
+                    "h": 1,
+                    "w": 24,
+                    "x": 0,
+                    "y": 48
+                },
+                "id": 45,
+                "panels": [],
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "refId": "A"
+                    }
+                ],
+                "title": "Performance Details",
+                "type": "row"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "description": "Total number of bytes allocated, even if freed",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "palette-classic"
+                        },
+                        "custom": {
+                            "axisBorderShow": false,
+                            "axisCenteredZero": false,
+                            "axisColorMode": "text",
+                            "axisLabel": "",
+                            "axisPlacement": "auto",
+                            "barAlignment": 0,
+                            "drawStyle": "line",
+                            "fillOpacity": 10,
+                            "gradientMode": "none",
+                            "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                            },
+                            "insertNulls": false,
+                            "lineInterpolation": "linear",
+                            "lineWidth": 1,
+                            "pointSize": 5,
+                            "scaleDistribution": {
+                                "type": "linear"
+                            },
+                            "showPoints": "never",
+                            "spanNulls": false,
+                            "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                            },
+                            "thresholdsStyle": {
+                                "mode": "off"
+                            }
+                        },
+                        "mappings": [],
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 80
+                                }
+                            ]
+                        },
+                        "unit": "bytes"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 7,
+                    "w": 8,
+                    "x": 0,
+                    "y": 49
+                },
+                "id": 7,
+                "options": {
+                    "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                    },
+                    "tooltip": {
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                    }
+                },
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[5m])",
+                        "hide": false,
+                        "intervalFactor": 2,
+                        "legendFormat": "{{prometheus}} - Allocated Bytes/s",
+                        "metric": "go_memstats_alloc_bytes",
+                        "range": true,
+                        "refId": "A",
+                        "step": 10
+                    }
+                ],
+                "title": "Allocations",
+                "type": "timeseries"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "description": "Total number of objects allocated",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "palette-classic"
+                        },
+                        "custom": {
+                            "axisBorderShow": false,
+                            "axisCenteredZero": false,
+                            "axisColorMode": "text",
+                            "axisLabel": "",
+                            "axisPlacement": "auto",
+                            "barAlignment": 0,
+                            "drawStyle": "line",
+                            "fillOpacity": 10,
+                            "gradientMode": "none",
+                            "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                            },
+                            "insertNulls": false,
+                            "lineInterpolation": "linear",
+                            "lineWidth": 1,
+                            "pointSize": 5,
+                            "scaleDistribution": {
+                                "type": "linear"
+                            },
+                            "showPoints": "never",
+                            "spanNulls": false,
+                            "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                            },
+                            "thresholdsStyle": {
+                                "mode": "off"
+                            }
+                        },
+                        "mappings": [],
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 80
+                                }
+                            ]
+                        },
+                        "unit": "bytes"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 7,
+                    "w": 8,
+                    "x": 8,
+                    "y": 49
+                },
+                "id": 84,
+                "options": {
+                    "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                    },
+                    "tooltip": {
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                    }
+                },
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "rate(go_gc_heap_allocs_objects_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                        "hide": false,
+                        "intervalFactor": 2,
+                        "legendFormat": "{{prometheus}}",
+                        "metric": "go_memstats_alloc_bytes",
+                        "range": true,
+                        "refId": "A",
+                        "step": 10
+                    }
+                ],
+                "title": "Objects allocated per second",
+                "type": "timeseries"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "palette-classic"
+                        },
+                        "custom": {
+                            "axisBorderShow": false,
+                            "axisCenteredZero": false,
+                            "axisColorMode": "text",
+                            "axisLabel": "",
+                            "axisPlacement": "auto",
+                            "barAlignment": 0,
+                            "drawStyle": "line",
+                            "fillOpacity": 10,
+                            "gradientMode": "none",
+                            "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                            },
+                            "insertNulls": false,
+                            "lineInterpolation": "linear",
+                            "lineWidth": 1,
+                            "pointSize": 5,
+                            "scaleDistribution": {
+                                "type": "linear"
+                            },
+                            "showPoints": "never",
+                            "spanNulls": false,
+                            "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                            },
+                            "thresholdsStyle": {
+                                "mode": "off"
+                            }
+                        },
+                        "mappings": [],
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 80
+                                }
+                            ]
+                        },
+                        "unit": "none"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 7,
+                    "w": 8,
+                    "x": 16,
+                    "y": 49
+                },
+                "id": 83,
+                "options": {
+                    "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                    },
+                    "tooltip": {
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                    }
+                },
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "go_gc_heap_objects_objects{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\"}",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{prometheus}}",
+                        "metric": "prometheus_local_storage_ingested_samples_total",
+                        "range": true,
+                        "refId": "B",
+                        "step": 10
+                    }
+                ],
+                "title": "Live objects on heap",
+                "type": "timeseries"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "palette-classic"
+                        },
+                        "custom": {
+                            "axisBorderShow": false,
+                            "axisCenteredZero": false,
+                            "axisColorMode": "text",
+                            "axisLabel": "",
+                            "axisPlacement": "auto",
+                            "barAlignment": 0,
+                            "drawStyle": "line",
+                            "fillOpacity": 0,
+                            "gradientMode": "none",
+                            "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                            },
+                            "insertNulls": false,
+                            "lineInterpolation": "linear",
+                            "lineWidth": 1,
+                            "pointSize": 5,
+                            "scaleDistribution": {
+                                "type": "linear"
+                            },
+                            "showPoints": "never",
+                            "spanNulls": false,
+                            "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                            },
+                            "thresholdsStyle": {
+                                "mode": "off"
+                            }
+                        },
+                        "mappings": [],
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 80
+                                }
+                            ]
+                        },
+                        "unit": "bytes"
+                    }
+                },
+                "gridPos": {
+                    "h": 7,
+                    "w": 8,
+                    "x": 0,
+                    "y": 56
+                },
+                "id": 6,
+                "options": {
+                    "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                    },
+                    "tooltip": {
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                    }
+                },
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "expr": "process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{prometheus}} - RSS",
+                        "metric": "process_resident_memory_bytes",
+                        "refId": "B",
+                        "step": 10
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "expr": "prometheus_local_storage_target_heap_size_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{prometheus}} - Target heap size",
+                        "metric": "go_memstats_alloc_bytes",
+                        "refId": "D",
+                        "step": 10
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "expr": "go_memstats_next_gc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{prometheus}} - Next GC",
+                        "metric": "go_memstats_next_gc_bytes",
+                        "refId": "C",
+                        "step": 10
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "expr": "go_memstats_alloc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{prometheus}} - Allocated",
+                        "metric": "go_memstats_alloc_bytes",
+                        "refId": "A",
+                        "step": 10
+                    }
+                ],
+                "title": "Memory",
+                "type": "timeseries"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "palette-classic"
+                        },
+                        "custom": {
+                            "axisBorderShow": false,
+                            "axisCenteredZero": false,
+                            "axisColorMode": "text",
+                            "axisLabel": "",
+                            "axisPlacement": "auto",
+                            "barAlignment": 0,
+                            "drawStyle": "line",
+                            "fillOpacity": 10,
+                            "gradientMode": "none",
+                            "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                            },
+                            "insertNulls": false,
+                            "lineInterpolation": "linear",
+                            "lineWidth": 1,
+                            "pointSize": 5,
+                            "scaleDistribution": {
+                                "type": "linear"
+                            },
+                            "showPoints": "never",
+                            "spanNulls": false,
+                            "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                            },
+                            "thresholdsStyle": {
+                                "mode": "off"
+                            }
+                        },
+                        "mappings": [],
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 80
+                                }
+                            ]
+                        },
+                        "unit": "none"
+                    }
+                },
+                "gridPos": {
+                    "h": 7,
+                    "w": 8,
+                    "x": 8,
+                    "y": 56
+                },
+                "id": 9,
+                "options": {
+                    "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                    },
+                    "tooltip": {
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                    }
+                },
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "expr": "irate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{prometheus}} - Irate",
+                        "metric": "prometheus_local_storage_ingested_samples_total",
+                        "refId": "A",
+                        "step": 10
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "expr": "rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[5m])",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{prometheus}} - 5m rate",
+                        "metric": "prometheus_local_storage_ingested_samples_total",
+                        "refId": "B",
+                        "step": 10
+                    }
+                ],
+                "title": "CPU",
+                "type": "timeseries"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "description": "",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "palette-classic"
+                        },
+                        "custom": {
+                            "axisBorderShow": false,
+                            "axisCenteredZero": false,
+                            "axisColorMode": "text",
+                            "axisLabel": "",
+                            "axisPlacement": "auto",
+                            "barAlignment": 0,
+                            "drawStyle": "line",
+                            "fillOpacity": 0,
+                            "gradientMode": "none",
+                            "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                            },
+                            "insertNulls": false,
+                            "lineInterpolation": "linear",
+                            "lineWidth": 1,
+                            "pointSize": 5,
+                            "scaleDistribution": {
+                                "type": "linear"
+                            },
+                            "showPoints": "never",
+                            "spanNulls": false,
+                            "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                            },
+                            "thresholdsStyle": {
+                                "mode": "off"
+                            }
+                        },
+                        "mappings": [],
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 80
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    }
+                },
+                "gridPos": {
+                    "h": 7,
+                    "w": 8,
+                    "x": 16,
+                    "y": 56
+                },
+                "id": 37,
+                "options": {
+                    "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                    },
+                    "tooltip": {
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                    }
+                },
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{prometheus}} - {{handler}}",
+                        "metric": "prometheus_local_storage_memory_chunkdescs",
+                        "range": true,
+                        "refId": "A",
+                        "step": 10
+                    }
+                ],
+                "title": "Avg HTTP request latency",
+                "type": "timeseries"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "palette-classic"
+                        },
+                        "custom": {
+                            "axisBorderShow": false,
+                            "axisCenteredZero": false,
+                            "axisColorMode": "text",
+                            "axisLabel": "",
+                            "axisPlacement": "auto",
+                            "barAlignment": 0,
+                            "drawStyle": "line",
+                            "fillOpacity": 10,
+                            "gradientMode": "none",
+                            "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                            },
+                            "insertNulls": false,
+                            "lineInterpolation": "linear",
+                            "lineWidth": 1,
+                            "pointSize": 5,
+                            "scaleDistribution": {
+                                "type": "linear"
+                            },
+                            "showPoints": "never",
+                            "spanNulls": false,
+                            "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                            },
+                            "thresholdsStyle": {
+                                "mode": "off"
+                            }
+                        },
+                        "mappings": [],
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 80
+                                }
+                            ]
+                        },
+                        "unit": "none"
+                    }
+                },
+                "gridPos": {
+                    "h": 7,
+                    "w": 8,
+                    "x": 0,
+                    "y": 63
+                },
+                "id": 82,
+                "options": {
+                    "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                    },
+                    "tooltip": {
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                    }
+                },
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "rate(go_gc_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\"}[10m]) / rate(go_gc_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\"}[10m]) ",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{prometheus}} - 10m rate",
+                        "metric": "prometheus_local_storage_ingested_samples_total",
+                        "range": true,
+                        "refId": "B",
+                        "step": 10
+                    }
+                ],
+                "title": "Average GC duration seconds",
+                "type": "timeseries"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "palette-classic"
+                        },
+                        "custom": {
+                            "axisBorderShow": false,
+                            "axisCenteredZero": false,
+                            "axisColorMode": "text",
+                            "axisLabel": "",
+                            "axisPlacement": "auto",
+                            "barAlignment": 0,
+                            "drawStyle": "line",
+                            "fillOpacity": 10,
+                            "gradientMode": "none",
+                            "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                            },
+                            "insertNulls": false,
+                            "lineInterpolation": "linear",
+                            "lineWidth": 1,
+                            "pointSize": 5,
+                            "scaleDistribution": {
+                                "type": "linear"
+                            },
+                            "showPoints": "never",
+                            "spanNulls": false,
+                            "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                            },
+                            "thresholdsStyle": {
+                                "mode": "off"
+                            }
+                        },
+                        "mappings": [],
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 80
+                                }
+                            ]
+                        },
+                        "unit": "none"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 7,
+                    "w": 8,
+                    "x": 8,
+                    "y": 63
+                },
+                "id": 81,
+                "options": {
+                    "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                    },
+                    "tooltip": {
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                    }
+                },
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "editorMode": "code",
+                        "expr": "rate(go_gc_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"test-.*\"}[10m]) *60",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{prometheus}} - 10m rate",
+                        "metric": "prometheus_local_storage_ingested_samples_total",
+                        "range": true,
+                        "refId": "B",
+                        "step": 10
+                    }
+                ],
+                "title": "GC runs per minute",
+                "type": "timeseries"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "description": "Average compactions that were executed for the partition",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "palette-classic"
+                        },
+                        "custom": {
+                            "axisBorderShow": false,
+                            "axisCenteredZero": false,
+                            "axisColorMode": "text",
+                            "axisLabel": "",
+                            "axisPlacement": "auto",
+                            "barAlignment": 0,
+                            "drawStyle": "line",
+                            "fillOpacity": 10,
+                            "gradientMode": "none",
+                            "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                            },
+                            "insertNulls": false,
+                            "lineInterpolation": "linear",
+                            "lineWidth": 1,
+                            "pointSize": 5,
+                            "scaleDistribution": {
+                                "type": "linear"
+                            },
+                            "showPoints": "never",
+                            "spanNulls": false,
+                            "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                            },
+                            "thresholdsStyle": {
+                                "mode": "off"
+                            }
+                        },
+                        "mappings": [],
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 80
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 7,
+                    "w": 8,
+                    "x": 0,
+                    "y": 70
+                },
+                "id": 33,
+                "options": {
+                    "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                    },
+                    "tooltip": {
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                    }
+                },
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "expr": "rate(prometheus_tsdb_compaction_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                        "format": "time_series",
+                        "hide": false,
+                        "intervalFactor": 2,
+                        "legendFormat": "{{prometheus}}",
+                        "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                        "refId": "A",
+                        "step": 10
+                    }
+                ],
+                "title": "Avg Compaction Time/s",
+                "type": "timeseries"
+            },
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "description": "WAL is used to get the backup when the prometheus server crashes. WAL stores the last 2hrs of data in memory. After that it has to truncate the data. So, this graph shows the latency of truncation",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "palette-classic"
+                        },
+                        "custom": {
+                            "axisBorderShow": false,
+                            "axisCenteredZero": false,
+                            "axisColorMode": "text",
+                            "axisLabel": "",
+                            "axisPlacement": "auto",
+                            "barAlignment": 0,
+                            "drawStyle": "line",
+                            "fillOpacity": 10,
+                            "gradientMode": "none",
+                            "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                            },
+                            "insertNulls": false,
+                            "lineInterpolation": "linear",
+                            "lineWidth": 1,
+                            "pointSize": 5,
+                            "scaleDistribution": {
+                                "type": "linear"
+                            },
+                            "showPoints": "never",
+                            "spanNulls": false,
+                            "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                            },
+                            "thresholdsStyle": {
+                                "mode": "off"
+                            }
+                        },
+                        "mappings": [],
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 80
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 7,
+                    "w": 8,
+                    "x": 8,
+                    "y": 70
+                },
+                "id": 65,
+                "options": {
+                    "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                    },
+                    "tooltip": {
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                    }
+                },
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "expr": "rate(prometheus_tsdb_wal_truncate_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_wal_truncate_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                        "format": "time_series",
+                        "interval": "",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{prometheus}} - Truncate Latency",
+                        "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                        "refId": "B",
+                        "step": 10
+                    }
+                ],
+                "title": "WAL Truncate Latency",
+                "type": "timeseries"
+            },
+            {
+                "collapsed": true,
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P86B77AEF8F12A5FA"
+                },
+                "gridPos": {
+                    "h": 1,
+                    "w": 24,
+                    "x": 0,
+                    "y": 77
+                },
+                "id": 47,
+                "panels": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "bytes"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 9,
+                            "w": 12,
+                            "x": 0,
+                            "y": 78
+                        },
+                        "id": 51,
+                        "options": {
+                            "legend": {
+                                "calcs": [
+                                    "mean",
+                                    "lastNotNull",
+                                    "max",
+                                    "min"
+                                ],
+                                "displayMode": "table",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "node_memory_MemTotal_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "hide": false,
+                                "intervalFactor": 1,
+                                "legendFormat": "{{node}} - Total memory",
+                                "refId": "E"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "node_memory_MemTotal_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"} - node_memory_MemFree_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"} - node_memory_Buffers_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"} - node_memory_Cached_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{node}} - Used",
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "node_memory_Buffers_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{node}} - Buffers",
+                                "refId": "B"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "node_memory_Cached_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{node}} - Cached",
+                                "refId": "C"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "node_memory_MemFree_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{node}} - Free",
+                                "refId": "D"
+                            }
+                        ],
+                        "title": "Memory",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "percentunit"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 9,
+                            "w": 12,
+                            "x": 12,
+                            "y": 78
+                        },
+                        "id": 53,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "irate(node_disk_io_time_seconds_total{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\",device!~'^(md\\\\\\\\d+$|dm-)'}[5m])",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{node}} - {{device}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "Disk I/O Utilisation",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 9,
+                            "w": 12,
+                            "x": 0,
+                            "y": 87
+                        },
+                        "id": 57,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "irate(node_context_switches_total{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}[5m])",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{node}} - Context Switches",
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "irate(node_intr_total{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}[5m])",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{node}} - Interrupts",
+                                "refId": "B"
+                            }
+                        ],
+                        "title": "Context Switches / Interrupts",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "Disk space used of all filesystems mounted",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "max": 100,
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "percent"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 9,
+                            "w": 12,
+                            "x": 12,
+                            "y": 87
+                        },
+                        "id": 61,
+                        "options": {
+                            "legend": {
+                                "calcs": [
+                                    "mean",
+                                    "lastNotNull",
+                                    "max",
+                                    "min"
+                                ],
+                                "displayMode": "table",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "100 - ((node_filesystem_avail_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\",device!~'rootfs'} * 100) / node_filesystem_size_bytes{node=~'(test+).*',device!~'rootfs'})",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{node}} - {{mountpoint}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "Disk Space Used Basic",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 9,
+                            "w": 12,
+                            "x": 0,
+                            "y": 96
+                        },
+                        "id": 59,
+                        "options": {
+                            "legend": {
+                                "calcs": [
+                                    "mean",
+                                    "lastNotNull",
+                                    "max",
+                                    "min"
+                                ],
+                                "displayMode": "table",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "node_load1{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{node}} - Load 1m",
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "node_load5{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{node}} - Load 5m",
+                                "refId": "B"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "node_load15{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{node}} - Load 15m",
+                                "refId": "C"
+                            }
+                        ],
+                        "title": "System Load",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "percentunit"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 9,
+                            "w": 12,
+                            "x": 12,
+                            "y": 96
+                        },
+                        "id": 55,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "1 - node_filesystem_free_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\",fstype!='rootfs',mountpoint!~'/(run|var).*',mountpoint!=''} / node_filesystem_size_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{node}} - {{mountpoint}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "Filesystem Fullness",
+                        "type": "timeseries"
+                    }
+                ],
+                "targets": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "refId": "A"
+                    }
+                ],
+                "title": "Node Metrics",
+                "type": "row"
+            },
+            {
+                "collapsed": true,
+                "gridPos": {
+                    "h": 1,
+                    "w": 24,
+                    "x": 0,
+                    "y": 78
+                },
+                "id": 80,
+                "panels": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "Time spent in queue_time mode, per second",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "s"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 0,
+                            "y": 89
+                        },
+                        "id": 63,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"queue_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"queue_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                                "format": "time_series",
+                                "hide": false,
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}}",
+                                "metric": "prometheus_local_storage_memory_chunkdescs",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Avg query engine timings/s - queue_time",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "Average Time spent in inner_eval mode, per second",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "s"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 8,
+                            "y": 89
+                        },
+                        "id": 24,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"inner_eval\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"inner_eval\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                                "format": "time_series",
+                                "hide": false,
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}}",
+                                "metric": "prometheus_local_storage_memory_chunkdescs",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Avg query engine timings/s - inner_eval",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "Average Time spent in result_sort mode, per second",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "s"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 16,
+                            "y": 89
+                        },
+                        "id": 62,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"result_sort\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"result_sort\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                                "format": "time_series",
+                                "hide": false,
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}}",
+                                "metric": "prometheus_local_storage_memory_chunkdescs",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Avg query engine timings/s - result_sort",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "Time spent in prepare_time mode, per second",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "s"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 0,
+                            "y": 96
+                        },
+                        "id": 64,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "editorMode": "code",
+                                "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"prepare_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"prepare_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                                "format": "time_series",
+                                "hide": false,
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}}",
+                                "metric": "prometheus_local_storage_memory_chunkdescs",
+                                "range": true,
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Avg query engine timings/s - prepare_time",
+                        "type": "timeseries"
+                    }
+                ],
+                "title": "Query Latency: Details",
+                "type": "row"
+            },
+            {
+                "collapsed": true,
+                "gridPos": {
+                    "h": 1,
+                    "w": 24,
+                    "x": 0,
+                    "y": 79
+                },
+                "id": 78,
+                "panels": [
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "Total number open and maximum file descriptors of both release and PR",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 0,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 0,
+                            "y": 69
+                        },
+                        "id": 41,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "process_max_fds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{prometheus}} - Max",
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "process_open_fds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 1,
+                                "legendFormat": "{{prometheus}} - Open",
+                                "refId": "B"
+                            }
+                        ],
+                        "title": "File Descriptors",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "Chunks are the collection of series of samples. The active series is known as the head chunk. Total of 120 samples are present in a chunk. This graph shows the total head chunks",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 0,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 8,
+                            "y": 69
+                        },
+                        "id": 2,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "prometheus_tsdb_head_chunks{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Chunks",
+                                "metric": "prometheus_local_storage_memory_chunks",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Head Chunks",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "Average runtime of garbage collection in the head block",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "s"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 16,
+                            "y": 69
+                        },
+                        "id": 29,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_tsdb_head_gc_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_head_gc_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - GC Time/s",
+                                "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Avg Head GC Time/s",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "Plots of minimum and maximum timestamp of the head block in reference to current time",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 35,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "dateTimeAsIso"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 0,
+                            "y": 76
+                        },
+                        "id": 28,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "prometheus_tsdb_head_min_time{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Min",
+                                "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                                "refId": "A",
+                                "step": 10
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "time() * 1000",
+                                "format": "time_series",
+                                "hide": false,
+                                "intervalFactor": 2,
+                                "legendFormat": "Now",
+                                "refId": "C"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "prometheus_tsdb_head_max_time{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Max",
+                                "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                                "refId": "B",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Head Time Range",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "This graph shows the total number of active appender transactions",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 8,
+                            "y": 76
+                        },
+                        "id": 26,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "prometheus_tsdb_head_active_appenders{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Head Appenders",
+                                "metric": "prometheus_local_storage_memory_series",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Head Active Appenders",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "Rule group describe the Prometheus alerts. These graph consist of two rules:\n- prometheus_rule_group_interval_seconds:  When the first notification was sent, wait for 'group_interval' to send a batch of new alerts that started firing for that group.\n- prometheus_rule_group_last_duration_seconds: It shows the last duration of each one of your groups in seconds\n",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 0,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "s"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 16,
+                            "y": 76
+                        },
+                        "id": 43,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "repeat": "RuleGroup",
+                        "repeatDirection": "h",
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "prometheus_rule_group_interval_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",rule_group=~\"$RuleGroup\"}\n",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Interval",
+                                "metric": "prometheus_local_storage_memory_chunkdescs",
+                                "refId": "A",
+                                "step": 10
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "prometheus_rule_group_last_duration_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",rule_group=~\"$RuleGroup\"}\n",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Last Duration",
+                                "metric": "prometheus_local_storage_memory_chunkdescs",
+                                "refId": "B",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Rule Group: $RuleGroup",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "Total number of times the database cut off block data from disk",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "none"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 0,
+                            "y": 83
+                        },
+                        "id": 8,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_tsdb_retention_cutoffs_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Retention Cutoffs",
+                                "metric": "last",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Retention Cutoffs/s",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 8,
+                            "y": 83
+                        },
+                        "id": 22,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_rule_group_iterations_missed_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])  ",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Rule group missed",
+                                "metric": "prometheus_local_storage_memory_chunkdescs",
+                                "refId": "B",
+                                "step": 10
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_rule_evaluation_failures_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Rule evals failed",
+                                "metric": "prometheus_local_storage_memory_chunkdescs",
+                                "refId": "C",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Rule group evaluation problems/s",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "ms"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 16,
+                            "y": 83
+                        },
+                        "id": 27,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_tsdb_compaction_chunk_range_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_range_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) or rate(prometheus_tsdb_compaction_chunk_range_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_range_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Chunk Time Range",
+                                "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "First Compaction, Avg Chunk Time Range",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "This graph shows the highest and lowest TSDB watermarks. The highest watermark represents the latest appender and the lowest watermark represents the oldest appender",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 0,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 0,
+                            "y": 90
+                        },
+                        "id": 67,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "prometheus_tsdb_isolation_low_watermark{namespace='prombench-${prNumber}'}",
+                                "legendFormat": "{{prometheus}} - low watermark",
+                                "refId": "A"
+                            },
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "prometheus_tsdb_isolation_high_watermark{namespace='prombench-${prNumber}'}",
+                                "interval": "",
+                                "legendFormat": "{{prometheus}} - high watermark",
+                                "refId": "B"
+                            }
+                        ],
+                        "title": "TSDB Isolation Watermarks",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "s"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 8,
+                            "y": 90
+                        },
+                        "id": 23,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_rule_group_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Rule evaluation duration",
+                                "metric": "prometheus_local_storage_memory_chunkdescs",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Evaluation time of rule groups/s",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "none"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 16,
+                            "y": 90
+                        },
+                        "id": 34,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Chunk Samples",
+                                "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "First Compaction, Avg Chunk Samples",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "Head chunk is converted to chunk when it is filled with 120 samples. This graph shows the total number of head chunks created",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "ops"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 0,
+                            "y": 97
+                        },
+                        "id": 25,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_tsdb_head_chunks_removed_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Removed",
+                                "metric": "prometheus_local_storage_chunk_ops_total",
+                                "refId": "B",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Head Chunks Removed",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "bytes"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 8,
+                            "y": 97
+                        },
+                        "id": 35,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_tsdb_compaction_chunk_size_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) or rate(prometheus_tsdb_compaction_chunk_size_bytes_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Bytes/Sample",
+                                "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "First Compaction, Avg Bytes/Sample",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "This graph the difference of highest and lowest of TSDB watermark and also shows the size of isolation linked-chain",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 0,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "short"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 16,
+                            "y": 97
+                        },
+                        "id": 68,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "prometheus_tsdb_isolation_high_watermark{namespace='prombench-${prNumber}'} - prometheus_tsdb_isolation_low_watermark{namespace='prombench-${prNumber}'}",
+                                "legendFormat": "{{prometheus}}",
+                                "refId": "A"
+                            }
+                        ],
+                        "title": "TSDB Isolation Watermarks Difference",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "This graph shows chunks created per second",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "ops"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 0,
+                            "y": 104
+                        },
+                        "id": 4,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_tsdb_head_chunks_created_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Created",
+                                "metric": "prometheus_local_storage_chunk_ops_total",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Head Chunks Created",
+                        "type": "timeseries"
+                    },
+                    {
+                        "datasource": {
+                            "type": "prometheus",
+                            "uid": "P86B77AEF8F12A5FA"
+                        },
+                        "description": "The latency distributions of fsync called by wal. High fsync duration (fsync_durations_seconds) indicates disk issues and might cause the cluster to be unstable",
+                        "fieldConfig": {
+                            "defaults": {
+                                "color": {
+                                    "mode": "palette-classic"
+                                },
+                                "custom": {
+                                    "axisBorderShow": false,
+                                    "axisCenteredZero": false,
+                                    "axisColorMode": "text",
+                                    "axisLabel": "",
+                                    "axisPlacement": "auto",
+                                    "barAlignment": 0,
+                                    "drawStyle": "line",
+                                    "fillOpacity": 10,
+                                    "gradientMode": "none",
+                                    "hideFrom": {
+                                        "legend": false,
+                                        "tooltip": false,
+                                        "viz": false
+                                    },
+                                    "insertNulls": false,
+                                    "lineInterpolation": "linear",
+                                    "lineWidth": 1,
+                                    "pointSize": 5,
+                                    "scaleDistribution": {
+                                        "type": "linear"
+                                    },
+                                    "showPoints": "never",
+                                    "spanNulls": false,
+                                    "stacking": {
+                                        "group": "A",
+                                        "mode": "none"
+                                    },
+                                    "thresholdsStyle": {
+                                        "mode": "off"
+                                    }
+                                },
+                                "mappings": [],
+                                "min": 0,
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green"
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 80
+                                        }
+                                    ]
+                                },
+                                "unit": "s"
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "h": 7,
+                            "w": 8,
+                            "x": 8,
+                            "y": 104
+                        },
+                        "id": 31,
+                        "options": {
+                            "legend": {
+                                "calcs": [],
+                                "displayMode": "list",
+                                "placement": "bottom",
+                                "showLegend": true
+                            },
+                            "tooltip": {
+                                "maxHeight": 600,
+                                "mode": "multi",
+                                "sort": "none"
+                            }
+                        },
+                        "targets": [
+                            {
+                                "datasource": {
+                                    "type": "prometheus",
+                                    "uid": "P86B77AEF8F12A5FA"
+                                },
+                                "expr": "rate(prometheus_tsdb_wal_fsync_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_wal_fsync_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
+                                "format": "time_series",
+                                "interval": "",
+                                "intervalFactor": 2,
+                                "legendFormat": "{{prometheus}} - Fsync Latency",
+                                "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "WAL Fsync Latency",
+                        "type": "timeseries"
+                    }
+                ],
+                "title": "Attic: Old panels, likely to remove",
+                "type": "row"
+            }
+        ],
+        "refresh": "",
+        "schemaVersion": 39,
+        "style": "dark",
+        "templating": {
+            "list": [
+                {
+                    "current": {
+                        "selected": false,
+                        "text": "All",
+                        "value": "$__all"
+                    },
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "definition": "",
+                    "hide": 2,
+                    "includeAll": true,
+                    "multi": false,
+                    "name": "RuleGroup",
+                    "options": [],
+                    "query": "prometheus_rule_group_last_duration_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
+                    "refresh": 2,
+                    "regex": ".*rule_group=\"(.*?)\".*",
+                    "skipUrlSync": false,
+                    "sort": 1,
+                    "tagValuesQuery": "",
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "current": {
+                        "selected": true,
+                        "text": "18013",
+                        "value": "18013"
+                    },
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P86B77AEF8F12A5FA"
+                    },
+                    "definition": "label_values(namespace)",
+                    "description": "PR number",
+                    "hide": 0,
+                    "includeAll": false,
+                    "multi": false,
+                    "name": "prNumber",
+                    "options": [],
+                    "query": {
+                        "query": "label_values(namespace)",
+                        "refId": "StandardVariableQuery"
+                    },
+                    "refresh": 1,
+                    "regex": "prombench-(\\d+)",
+                    "skipUrlSync": false,
+                    "sort": 0,
+                    "type": "query"
+                }
+            ]
+        },
+        "time": {
+            "from": "now-3h",
+            "to": "now"
+        },
+        "timeRangeUpdatedDuringEditOrView": false,
+        "timepicker": {
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
+            ]
+        },
+        "timezone": "browser",
+        "title": "Prombench",
+        "uid": "7gmLoNDmz",
+        "version": 4
     }


### PR DESCRIPTION
See preview http://prombench.prometheus.io/grafana/d/afbm2esx87klce/prombench-atbwplotka?orgId=1&var-RuleGroup=All&var-prNumber=18013

Thanks @bboreham for brainstorming session on what to improve! 

Changes:
* Dashboard starts with `Acceptance` rows for Mem, CPU and HTTP latency for quick, ideally single number that shows high level look on important performance numbers.
* Functional check (collapsed) is a set of old panels that help to tell if load, sample/s, series match (are we consuming same amount of data)
   * load generator panel has step 61s to avoid aliasing
* Performance Details is a set of old panels for more drill downs.  Added extra GC metrics.
* Query Latency: details row drill down stages of query engine as we had in the past
* Panels we do not understand or they don't work or they were useful only for a single issue are now in `Attic` panel. We can remove them later unless they will be objections

This dashboard could be better and more perfect, but let's just try iterate etc (: 