### PR TITLE
Use server-side apply for ConfigMaps to avoid annotation size limits

### DIFF
--- a/prombench/manifests/cluster-infra/grafana_dashboard_dashboards_noparse.yaml
+++ b/prombench/manifests/cluster-infra/grafana_dashboard_dashboards_noparse.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboards
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: "-"
 data:
   node-metrics.json: |
     {
@@ -3928,7 +3930,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_tsdb_compaction_chunk_range_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_range_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
+              "expr": "rate(prometheus_tsdb_compaction_chunk_range_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_range_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) or rate(prometheus_tsdb_compaction_chunk_range_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_range_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Chunk Time Range",

--- a/scripts/sync-dashboards-to-configmap.sh
+++ b/scripts/sync-dashboards-to-configmap.sh
@@ -4,6 +4,8 @@ echo 'apiVersion: v1' > prombench/manifests/cluster-infra/grafana_dashboard_dash
 echo 'kind: ConfigMap' >> prombench/manifests/cluster-infra/grafana_dashboard_dashboards_noparse.yaml
 echo 'metadata:' >> prombench/manifests/cluster-infra/grafana_dashboard_dashboards_noparse.yaml
 echo '  name: grafana-dashboards' >> prombench/manifests/cluster-infra/grafana_dashboard_dashboards_noparse.yaml
+echo '  annotations:' >> prombench/manifests/cluster-infra/grafana_dashboard_dashboards_noparse.yaml
+echo '    kubectl.kubernetes.io/last-applied-configuration: "-"' >> prombench/manifests/cluster-infra/grafana_dashboard_dashboards_noparse.yaml
 echo 'data:' >> prombench/manifests/cluster-infra/grafana_dashboard_dashboards_noparse.yaml
 
 # Loop over files in prombench/manifests/cluster-infra/dashboards.


### PR DESCRIPTION
The kubectl.kubernetes.io/last-applied-configuration annotation can exceed the 262144 byte limit for large ConfigMaps like grafana-dashboards.

Changes:
- Modified configMapApply() to use server-side apply via Patch method
- Added opt-out annotation to prevent storing last-applied-configuration
- Updated dashboard generation script to include the annotation

Server-side apply doesn't store configuration in annotations, making it suitable for large resources while providing better conflict resolution