### PR TITLE
chore: add CODEOWNERS for automatic PR review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @kakkoyun @bwplotka


### PR DESCRIPTION
- Adds `.github/CODEOWNERS` assigning `@kakkoyun` and `@bwplotka` as default reviewers for all files
- Matches the existing `MAINTAINERS` file
- Ensures PRs automatically request reviews from maintainers

Consistent with the CODEOWNERS already added to `client_golang` and `promu`.