### PR TITLE
ci: declare permissions on ci, generate-dashboards, grafana_dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   yamllint:
     name: Yaml lint

--- a/.github/workflows/generate-dashboards.yaml
+++ b/.github/workflows/generate-dashboards.yaml
@@ -8,6 +8,9 @@ on:
     paths:
     - 'prombench/manifests/cluster-infra/grafana_dashboard_dashboards_noparse.yaml'
     - 'prombench/manifests/cluster-infra/dashboards/**'
+permissions:
+  contents: read
+
 jobs:
   verify_dashboard_generation:
     name: Verify Dashboard Generation

--- a/.github/workflows/grafana_dashboard.yaml
+++ b/.github/workflows/grafana_dashboard.yaml
@@ -5,6 +5,11 @@ on:
     - master
     paths:
     - 'prombench/manifests/cluster-infra/grafana_dashboard_dashboards_noparse.yaml'
+# Posts a success/failure comment on the PR associated with the commit.
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   apply_grafana_dashboard:
     name: Apply Dashboard


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` on the three workflows still inheriting org defaults:

- `ci.yml` — `contents: read` for yamllint.
- `generate-dashboards.yaml` — `contents: read` for the dashboard-generation diff check.
- `grafana_dashboard.yaml` — `contents: read` + `pull-requests: write`. The success/failure comment uses `curl -X POST .../issues/$PR_NUMBER/comments` with `GITHUB_TOKEN`.