### PR TITLE
ci: declare workflow-level `contents: read` on ci, generate-dashboards, grafana_dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   yamllint:
     name: Yaml lint

--- a/.github/workflows/generate-dashboards.yaml
+++ b/.github/workflows/generate-dashboards.yaml
@@ -8,6 +8,9 @@ on:
     paths:
     - 'prombench/manifests/cluster-infra/grafana_dashboard_dashboards_noparse.yaml'
     - 'prombench/manifests/cluster-infra/dashboards/**'
+permissions:
+  contents: read
+
 jobs:
   verify_dashboard_generation:
     name: Verify Dashboard Generation

--- a/.github/workflows/grafana_dashboard.yaml
+++ b/.github/workflows/grafana_dashboard.yaml
@@ -5,6 +5,9 @@ on:
     - master
     paths:
     - 'prombench/manifests/cluster-infra/grafana_dashboard_dashboards_noparse.yaml'
+permissions:
+  contents: read
+
 jobs:
   apply_grafana_dashboard:
     name: Apply Dashboard


### PR DESCRIPTION
All three workflows run validation only; no GitHub API writes from the workflows.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.