### PR TITLE
Group aws-sdk updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,7 @@ updates:
       go.opentelemetry.io:
         patterns:
           - "go.opentelemetry.io/*"
+      aws-sdk-v2:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2*"
     open-pull-requests-limit: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_call:
   push:
+    branches: [main, master, 'release-*']
+    tags: ['v*']
+
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,8 @@ name: Publish
 on:
   workflow_call:
   push:
-    branches:
-      - master
+    branches: [main, master, 'release-*']
+    tags: ['v*']
 
 permissions:
   contents: read


### PR DESCRIPTION
Group `github.com/aws/aws-sdk-go-v2*` Dependabot updates to avoid lots of PRs for the same package family.